### PR TITLE
make docs: don't crash on non-existing autogenerated files

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -39,8 +39,8 @@ coverage:
 	open htmlcov/index.html
 
 docs:
-	rm docs/{{ cookiecutter.repo_name }}.rst
-	rm docs/modules.rst
+	rm -f docs/{{ cookiecutter.repo_name }}.rst
+	rm -f docs/modules.rst
 	sphinx-apidoc -o docs/ {{ cookiecutter.repo_name }}
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html


### PR DESCRIPTION
The autogenerated index and module index might not exist in a new project. 

Attempting to remove them will cause an error if they don't exist, so we pass the -f flag to rm to ignore the error.
