### PR TITLE
make docs: Use project root as first element in PYTHONPATH

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -21,7 +21,7 @@ import sys, os
 
 cwd = os.getcwd()
 parent = os.path.dirname(cwd)
-sys.path.append(parent)
+sys.path.insert(0, parent)
 
 import {{ cookiecutter.repo_name }}
 


### PR DESCRIPTION
When we use `sys.path.append(parent)`, `parent` is the last element in the path. 

Consequently, if the module we're building docs for is already installed, then that one will be installed, and `version = module.__version__` will use the version of the installed module instead of that of the source package.

Inserting the project root as first element in the PYTHONPATH lets us ensure that the source package is imported, and that its version is used.
