### PR TITLE
Add htmlcov to .gitignore

### DIFF
--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+htmlcov
 
 # Translations
 *.mo


### PR DESCRIPTION
The default `make coverage` generates HTML coverage reports in `htmlcov`. Let's gitignore that folder!
