### PR TITLE
Changing the Source Control Server to Bitbucket.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Don't worry, you have options:
 Similar Cookiecutter Templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* `audreyr/cookiecutter-pypackage`_: The original pypackage, uses unittest
+* `audreyr/cookiecutter-pypackage`: The original pypackage, uses unittest
 for testing and other minor changes.
 
 Fork This / Create Your Own

--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://bitbucket.org{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/issues.
+Report bugs at https://bitbucket.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/issues.
 
 If you are reporting a bug, please include:
 
@@ -43,7 +43,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://bitbucket.org{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/issues.
+The best way to send feedback is to file an issue at https://bitbucket.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/issues.
 
 If you are proposing a feature:
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=readme + '\n\n' + history,
     author='{{ cookiecutter.full_name }}',
     author_email='{{ cookiecutter.email }}',
-    url='https://bitbucket.org{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',
+    url='https://bitbucket.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',
     packages=[
         '{{ cookiecutter.repo_name }}',
     ],


### PR DESCRIPTION
This pull request only add a bitbucket.org Source Control Server instead of Github.com
