### PR TITLE
Fix target URL for PyPI badge

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -9,7 +9,7 @@
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
 
 .. image:: https://pypip.in/d/{{ cookiecutter.repo_name }}/badge.png
-        :target: https://crate.io/packages/{{ cookiecutter.repo_name }}?version=latest
+        :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}
 
 
 {{ cookiecutter.project_short_description}}


### PR DESCRIPTION
crate.io is no longer the awesome PyPI mirror it once was before (maybe someday on PyPI proper). It's now an Austrian Big Data firm.

This fixes the link so it goes to pypi proper and goes to the base package as `?version=latest` is not valid on PyPI proper.
