### PR TITLE
Add Python 3.4 support by default

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -3,6 +3,7 @@
 language: python
 
 python:
+  - "3.4"
   - "3.3"
   - "2.7"
   - "2.6"

--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -99,7 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check 
+3. The pull request should work for Python 2.6, 2.7, and 3.3, 3.4, and for PyPy. Check
    https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
     test_suite='tests',
     tests_require=test_requirements

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33
+envlist = py26, py27, py33, py34
 
 [testenv]
 setenv =


### PR DESCRIPTION
An alternative is to add completely remove Python 3.3 support and replace it with Python 3.4.
