### PR TITLE
Trim trailing whitespace from RST files

### DIFF
--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -3,7 +3,7 @@ Contributing
 ============
 
 Contributions are welcome, and they are greatly appreciated! Every
-little bit helps, and credit will always be given. 
+little bit helps, and credit will always be given.
 
 You can contribute in many ways:
 
@@ -36,7 +36,7 @@ is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-{{ cookiecutter.project_name }} could always use more documentation, whether as part of the 
+{{ cookiecutter.project_name }} could always use more documentation, whether as part of the
 official {{ cookiecutter.project_name }} docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
@@ -71,7 +71,7 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for loc
 4. Create a branch for local development::
 
     $ git checkout -b name-of-your-bugfix-or-feature
-   
+
    Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
@@ -80,7 +80,7 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for loc
     $ python setup.py test
     $ tox
 
-   To get flake8 and tox, just pip install them into your virtualenv. 
+   To get flake8 and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -4,7 +4,7 @@
 
 .. image:: https://badge.fury.io/py/{{ cookiecutter.repo_name }}.png
     :target: http://badge.fury.io/py/{{ cookiecutter.repo_name }}
-    
+
 .. image:: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}.png?branch=master
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
 


### PR DESCRIPTION
This change only removes trailing spaces from the ends of lines.
