### PR TITLE
Removing `__pycache__` on `make clean-pyc`.

### DIFF
--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -23,6 +23,7 @@ clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
 
 lint:
 	flake8 {{ cookiecutter.repo_name }} tests


### PR DESCRIPTION
The `__pycache__` directories still exists after running `make clean-pyc`. IMO this should unexpected behaviour.
