### PR TITLE
Document the make rules instead of the plain commands

### DIFF
--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -81,7 +81,7 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_slug }}` for 
 
     $ make lint
     $ make test
-  Or
+    Or
     $ make test-all
 
    To get flake8 and tox, just pip install them into your virtualenv.

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -79,9 +79,10 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_slug }}` for 
 5. When you're done making changes, check that your changes pass flake8 and the
    tests, including testing other Python versions with tox::
 
-    $ flake8 {{ cookiecutter.project_slug }} tests
-    $ python setup.py test or pytest
-    $ tox
+    $ make lint
+    $ make test
+  Or
+    $ make test-all
 
    To get flake8 and tox, just pip install them into your virtualenv.
 


### PR DESCRIPTION
The "getting started" instructions show the detailed bash commands to perform tests, linting etc.
Users should be taught there are handy/no-brainer make rules which take care of everything! 

Also those commands depend on the particular choices made at the generation of the package and may not be relevant.