### PR TITLE
Add minimal configuration file for Read the Docs

### DIFF
--- a/{{cookiecutter.project_slug}}/.readthedocs.yml
+++ b/{{cookiecutter.project_slug}}/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Set requirements required to build your docs
+python:
+  - method: pip
+    path: .


### PR DESCRIPTION
This is the minimal configuration file for Read the Docs Config File V2 --which is the recommended way to setup a project on Read the Docs. See https://docs.readthedocs.io/en/stable/config-file/v2.html

There are other options that can be added by default if you want, but I think this is a good first version.

In summary, this file will tell Read the Docs to use:

- Sphinx with the `docs/conf.py` file
- Python 3 by default
- Build HTML format only (no ePUB, no PDF, no HTMLZip)
- Install default Read the Docs requirements to build the docs (Sphinx, etc)
- Install the Python package itself (required by `sphinx.ext.autodoc`)

Other things to consider:

- Use [Read the Docs theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/) instead of Alabaster
- Use [`sphinx-autoapi`](https://sphinx-autoapi.readthedocs.io/en/latest/) instead of `autodoc` to avoid installing dependencies to document the API
- Ask at startup for documentation output formats
- Ask at startup if the package needs `conda` to create the environment instead of regular virtualenv its docs

Let me know what you think!

Closes #411