### PR TITLE
Introduces Black linter (disabled by default), closes #575

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
   "pypi_username": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",
   "use_pytest": "n",
+  "use_black": "n",
   "use_pypi_deployment_with_travis": "y",
   "add_pyup_badge": "n",
   "command_line_interface": ["Click", "Argparse", "No command-line interface"],

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -5,6 +5,7 @@ import sys
 import subprocess
 import yaml
 import datetime
+import pytest
 from cookiecutter.utils import rmtree
 
 from click.testing import CliRunner
@@ -331,3 +332,16 @@ def test_bake_with_argparse_console_script_cli(cookies):
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
     assert 'Show this message' in help_result.output
+
+
+@pytest.mark.parametrize("use_black,expected", [("y", True), ("n", False)])
+def test_black(cookies, use_black, expected):
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={'use_black': use_black}
+    ) as result:
+        assert result.project.isdir()
+        requirements_path = result.project.join('requirements_dev.txt')
+        assert ("black" in requirements_path.read()) is expected
+        makefile_path = result.project.join('Makefile')
+        assert ("black --check" in makefile_path.read()) is expected

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -47,8 +47,15 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
+lint/flake8: ## check style with flake8
 	flake8 {{ cookiecutter.project_slug }} tests
+
+{%- if cookiecutter.use_black == 'y' %}
+lint/black: ## check style with black
+	black --check {{ cookiecutter.project_slug }} tests
+{%- endif %}
+
+lint: lint/flake8{%- if cookiecutter.use_black == 'y' %} lint/black{%- endif %} ## check style
 
 test: ## run tests quickly with the default Python
 {%- if cookiecutter.use_pytest == 'y' %}

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -11,3 +11,5 @@ twine==1.14.0
 Click==7.0{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}
 pytest==6.2.4{% endif %}
+{% if cookiecutter.use_black == 'y' -%}
+black==21.7b0{% endif %}


### PR DESCRIPTION
This is a first iteration with things kept simple. In the future I think we should do things like actually running both linters (flake and black) on the generated project via `tests/test_bake_project.py`.
Among other things I can also later provide a `make format` target that automatically fixes linter issues.
If things go as planned we can also add the `isort` linting option too