### PR TITLE
Simplifies PyPI deployment over Travis configuration

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,6 @@
   "project_name": "Python Boilerplate",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
-  "pypi_username": "{{ cookiecutter.github_username }}",
   "version": "0.1.0",
   "use_pytest": "n",
   "use_pypi_deployment_with_travis": "y",

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -29,9 +29,6 @@ project_short_description
 release_date
     The date of the first release.
 
-pypi_username
-    Your Python Package Index account username.
-
 year
     The year of the initial package copyright in the license file.
 

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -14,16 +14,14 @@ install: pip install -U tox-travis
 script: tox
 
 {% if cookiecutter.use_pypi_deployment_with_travis == 'y' -%}
-# Assuming you have installed the travis-ci CLI tool, after you
-# create the Github repo and add it to Travis, run the
-# following command to finish PyPI deployment setup:
-# $ travis encrypt --add deploy.password
+# Create a new token PyPI token for your project via:
+# https://pypi.org/manage/account/token/
+# Then add it to the `PYPI_PASSWORD` environment variable in your Travis project settings:
+# https://travis-ci.com/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/settings
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
-  user: {{ cookiecutter.pypi_username }}
-  password:
-    secure: PLEASE_REPLACE_ME
+  user: "__token__"
   on:
     tags: true
     repo: {{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}


### PR DESCRIPTION
Leverages the not so well documented token and `PYPI_PASSWORD` feature.
It's actually already possible in Travis v1 to use this environment
variable refs:
https://github.com/travis-ci/dpl/blob/v1.10.15/lib/dpl/provider/pypi.rb#L12
Note that the `__token__` user is a PyPI feature, refs:
https://pypi.org/help/#apitoken
This is more secure than user and password as tokens are generated with
uploaded only permissions and can be scoped to a given project.