### PR TITLE
The old link to help returns a 404 and was not to the pypi help.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -165,7 +165,7 @@ See `PyPI Help`_ for more information about submitting a package.
 Here's a release checklist you can use: https://gist.github.com/audreyr/5990987
 
 .. _`PyPI`: https://pypi.python.org/pypi
-.. _`PyPI Help`: http://peterdowns.com/posts/first-time-with-pypi.html
+.. _`PyPI Help`: https://pypi.org/help/#publishing
 
 
 Having problems?


### PR DESCRIPTION
I have linked to the pypi page for publishing