### PR TITLE
Explain project_slug locations in docs

### DIFF
--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -21,7 +21,7 @@ project_name
     The name of your new Python package project. This is used in documentation, so spaces and any characters are fine here.
     
 project_slug
-    The namespace of your Python package. This should be Python import-friendly. Typically, it is the slugified version of project_name.
+    The namespace of your Python package. This should be Python import-friendly. Typically, it is the slugified version of project_name. Note: your PyPi project and Travis links will use project_slug, so change those in the README afterwards.
 
 project_short_description
     A 1-sentence description of what your Python package does.


### PR DESCRIPTION
When I recently created a package, I was surprised to not be able to see my Travis builds using the README badge. And then I realized that the badge thinks that the repository is the project_slug which is formatted to have an \_ so that Python can properly import the package. I just wanted some clarification in the docs in case some other people are confused in the future.