### PR TITLE
Fixed broken rtd docs link.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 pytest==5.3.1
 tox==3.14.1
 cookiecutter>=1.4.0
-pytest-cookies==0.4.0
+pytest-cookies==0.5.1
 alabaster==0.7.12
 watchdog==0.9.0

--- a/{{cookiecutter.project_slug}}/README.rst
+++ b/{{cookiecutter.project_slug}}/README.rst
@@ -11,7 +11,7 @@
         :target: https://travis-ci.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
 .. image:: https://readthedocs.org/projects/{{ cookiecutter.project_slug | replace("_", "-") }}/badge/?version=latest
-        :target: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest
+        :target: https://{{ cookiecutter.project_slug | replace("_", "-") }}.readthedocs.io/en/latest/?version=latest
         :alt: Documentation Status
 {%- endif %}
 


### PR DESCRIPTION
Problem: Query parameter includes a typo.

Expected: `?version=latest`

Actual: `?badge=latest`

@audreyfeldroy @veit @pydanny 