### PR TITLE
Deprecate EOL Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.8
   - 3.7
   - 3.6
-  - 3.5
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,7 +73,7 @@ development. Please note this documentation assumes you already have
 
 ::
 
-3. Assuming you have virtualenv installed (If you have Python3.5 this should
+3. Assuming you have virtualenv installed (If you have Python 3.6 this should
    already be there), you can create a new environment for your local
    development by typing:
 
@@ -171,7 +171,7 @@ Before you submit a pull request, check that it meets these guidelines:
    new functionality into a function with a docstring, and add the feature to
    the list in README.rst.
 
-3. The pull request should work for Python 3.5, 3.6 and 3.7, 3.8 and for PyPy. Check
+3. The pull request should work for Python 3.6 and 3.7, 3.8 and for PyPy. Check
    https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests and
    make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Features
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``pytest``
 * Travis-CI_: Ready for Travis Continuous Integration testing
-* Tox_ testing: Setup to easily test for Python 3.5, 3.6, 3.7, 3.8
+* Tox_ testing: Setup to easily test for Python 3.6, 3.7, 3.8
 * Sphinx_ docs: Documentation ready for generation with, for example, `Read the Docs`_
 * bump2version_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -15,7 +15,7 @@ Windows Issues
 
 * Some people have reported issues using git bash; try using the Command Terminal instead.
 
-* Virtual environments can sometimes be tricky on Windows. If you have Python 3.5 or above installed (recommended), this should get you a virtualenv named ``myenv`` created inside the current folder:
+* Virtual environments can sometimes be tricky on Windows. If you have Python 3.6 or above installed (recommended), this should get you a virtualenv named ``myenv`` created inside the current folder:
 
 .. code-block:: powershell
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email='aroy@alum.mit.edu',
     url='https://github.com/audreyr/cookiecutter-pypackage',
     keywords=['cookiecutter', 'template', 'package', ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
@@ -20,7 +20,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37,py38 pypy, docs
+envlist = py36, py37,py38 pypy, docs
 skipsdist = true
 
 [travis]
@@ -7,7 +7,6 @@ python =
     3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
 
 [testenv:docs]
 basepython=python

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.8
   - 3.7
   - 3.6
-  - 3.5
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -27,7 +27,7 @@ test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest>=3',{%- end
 setup(
     author="{{ cookiecutter.full_name.replace('\"', '\\\"') }}",
     author_email='{{ cookiecutter.email }}',
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
@@ -36,7 +36,6 @@ setup(
 {%- endif %}
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py35, py36, py37, py38, flake8
+envlist = py36, py37, py38, flake8
 
 [travis]
 python =
     3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Python 3.5 reached end of life according to https://www.python.org/dev/peps/pep-0478/ and should not be supported.

Therefore minimum Python version in setup.py is updated to 3.6, which is supported only till the end of 2021 according to https://devguide.python.org/#status-of-python-branches