### PR TITLE
Remove deprecated setup_requires and pytest-runner

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -220,9 +220,7 @@ def test_using_pytest(cookies):
         lines = test_file_path.readlines()
         assert "import pytest" in ''.join(lines)
         # Test the new pytest target
-        run_inside_dir('python setup.py pytest', str(result.project)) == 0
-        # Test the test alias (which invokes pytest)
-        run_inside_dir('python setup.py test', str(result.project)) == 0
+        run_inside_dir('pytest', str(result.project)) == 0
 
 
 def test_not_using_pytest(cookies):

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -10,5 +10,4 @@ twine==1.14.0
 {% if cookiecutter.command_line_interface|lower == 'click' -%}
 Click==7.0{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}
-pytest==4.6.5
-pytest-runner==5.1{% endif %}
+pytest==4.6.5{% endif %}

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -10,4 +10,4 @@ twine==1.14.0
 {% if cookiecutter.command_line_interface|lower == 'click' -%}
 Click==7.0{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}
-pytest==4.6.5{% endif %}
+pytest==6.2.4{% endif %}

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -17,12 +17,7 @@ universal = 1
 [flake8]
 exclude = docs
 
-[aliases]
-# Define setup.py command aliases here
 {%- if cookiecutter.use_pytest == 'y' %}
-test = pytest
-
 [tool:pytest]
 collect_ignore = ['setup.py']
 {%- endif %}
-

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -12,8 +12,6 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [{%- if cookiecutter.command_line_interface|lower == 'click' %}'Click>=7.0',{%- endif %} ]
 
-setup_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest-runner',{%- endif %} ]
-
 test_requirements = [{%- if cookiecutter.use_pytest == 'y' %}'pytest>=3',{%- endif %} ]
 
 {%- set license_classifiers = {
@@ -57,7 +55,6 @@ setup(
     keywords='{{ cookiecutter.project_slug }}',
     name='{{ cookiecutter.project_slug }}',
     packages=find_packages(include=['{{ cookiecutter.project_slug }}', '{{ cookiecutter.project_slug }}.*']),
-    setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}',


### PR DESCRIPTION
See: 
- https://github.com/pytest-dev/pytest-runner/issues/57
- https://github.com/pypa/setuptools/issues/1684

@audreyfeldroy 