### PR TITLE
Add new fork to Similar Cookiecutter Templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,8 @@ Similar Cookiecutter Templates
 
 * `zillionare/cookiecutter-pypackage`_: A template containing Poetry_, Mkdocs_, Github CI and many more. It's a template and a package also (can be installed with `pip`)
 
+* `waynerv/cookiecutter-pypackage`_: A fork using Poetry_, Mkdocs_, Pre-commit_, Black_ and Mypy_. Run test, staging and release workflows with GitHub Actions, automatically generate release notes from CHANGELOG.
+
 * Also see the `network`_ and `family tree`_ for this repo. (If you find
   anything that should be listed here, please add it and send a pull request!)
 
@@ -140,6 +142,9 @@ make my own packaging experience better.
 .. _Poetry: https://python-poetry.org/
 .. _PyPi: https://pypi.python.org/pypi
 .. _Mkdocs: https://pypi.org/project/mkdocs/
+.. _Pre-commit: https://pre-commit.com/
+.. _Black: https://black.readthedocs.io/en/stable/
+.. _Mypy: https://mypy.readthedocs.io/en/stable/
 
 .. _`Nekroze/cookiecutter-pypackage`: https://github.com/Nekroze/cookiecutter-pypackage
 .. _`tony/cookiecutter-pypackage-pythonic`: https://github.com/tony/cookiecutter-pypackage-pythonic
@@ -148,6 +153,7 @@ make my own packaging experience better.
 .. _`briggySmalls/cookiecutter-pypackage`: https://github.com/briggySmalls/cookiecutter-pypackage
 .. _`veit/cookiecutter-namespace-template`: https://github.com/veit/cookiecutter-namespace-template
 .. _`zillionare/cookiecutter-pypackage`: https://zillionare.github.io/cookiecutter-pypackage/
+.. _`waynerv/cookiecutter-pypackage`: https://waynerv.github.io/cookiecutter-pypackage/
 .. _github comparison view: https://github.com/tony/cookiecutter-pypackage-pythonic/compare/audreyr:master...master
 .. _`network`: https://github.com/audreyr/cookiecutter-pypackage/network
 .. _`family tree`: https://github.com/audreyr/cookiecutter-pypackage/network/members


### PR DESCRIPTION
Adding waynerv/cookiecutter-pypackage to list of similar templates. Main differences:

- Using Poetry to manage packaging and dependencies.
- Run test, staging and release workflows with GitHub Actions.
- Added Pre-commit hooks to automatically run format, lint and static type check before every git commit.