### PR TITLE
Fix conflict between click and black

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -8,7 +8,7 @@ coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
 {% if cookiecutter.command_line_interface|lower == 'click' -%}
-Click==7.0{% endif %}
+Click==7.1.2{% endif %}
 {% if cookiecutter.use_pytest == 'y' -%}
 pytest==6.2.4{% endif %}
 {% if cookiecutter.use_black == 'y' -%}


### PR DESCRIPTION
The version of black used in this cookiecutter template [requires](https://github.com/psf/black/blob/21.7b0/setup.py#L75) `click>=7.1.2`. This conflict prevents tox from running tests.