### PR TITLE
Update tox website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ make my own packaging experience better.
 
 
 .. _Travis-CI: http://travis-ci.org/
-.. _Tox: http://testrun.org/tox/
+.. _Tox: https://tox.wiki/en/latest/
 .. _Sphinx: http://sphinx-doc.org/
 .. _Read the Docs: https://readthedocs.io/
 .. _`pyup.io`: https://pyup.io/


### PR DESCRIPTION
testrun.org/tox/ return error 404. New website is tox.wiki