### PR TITLE
Fix Issue #670 : bake context argument should match the case 

### DIFF
--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -269,7 +269,7 @@ def test_bake_with_no_console_script(cookies):
 
 
 def test_bake_with_console_script_files(cookies):
-    context = {'command_line_interface': 'click'}
+    context = {'command_line_interface': 'Click'}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
     found_project_files = os.listdir(project_dir)
@@ -281,7 +281,7 @@ def test_bake_with_console_script_files(cookies):
 
 
 def test_bake_with_argparse_console_script_files(cookies):
-    context = {'command_line_interface': 'argparse'}
+    context = {'command_line_interface': 'Argparse'}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
     found_project_files = os.listdir(project_dir)
@@ -293,7 +293,7 @@ def test_bake_with_argparse_console_script_files(cookies):
 
 
 def test_bake_with_console_script_cli(cookies):
-    context = {'command_line_interface': 'click'}
+    context = {'command_line_interface': 'Click'}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
     module_path = os.path.join(project_dir, 'cli.py')
@@ -314,7 +314,7 @@ def test_bake_with_console_script_cli(cookies):
 
 
 def test_bake_with_argparse_console_script_cli(cookies):
-    context = {'command_line_interface': 'argparse'}
+    context = {'command_line_interface': 'Argparse'}
     result = cookies.bake(extra_context=context)
     project_path, project_slug, project_dir = project_info(result)
     module_path = os.path.join(project_dir, 'cli.py')


### PR DESCRIPTION
To my understanding, this would solve the issue describe in #670. It fallback to the first item in the list if the case is not respected.  It becomes a problem then if you try swapping argument order.

Also, this change likely causes the argparse test to fail, but this is maybe expected as you are testing  non Click input with the Click RunnerCli 