### PR TITLE
Use current git branch naming scheme in tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -75,7 +75,7 @@ You will find one folder named after the ``[project_slug]``. Move into this fold
     git add .
     git commit -m "Initial skeleton."
     git remote add origin git@github.com:myusername/mypackage.git
-    git push -u origin master
+    git push -u origin main
 
 Where ``myusername`` and ``mypackage`` are adjusted for your username and package name.
 


### PR DESCRIPTION
Git(hub) changed the default `master` branch name to `main`, so a newly created project should follow this current naming policy.