### PR TITLE
Update setup.cfg

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -19,5 +19,5 @@ exclude = docs
 
 {%- if cookiecutter.use_pytest == 'y' %}
 [tool:pytest]
-collect_ignore = ['setup.py']
+addopts = --ignore=setup.py
 {%- endif %}


### PR DESCRIPTION
Replace collect_ignore with addopts as the former is not available anymore.

```
[tool:pytest]
collect_ignore = ['setup.py']
```

Throws the warning when running pytest:

> PytestConfigWarning: Unknown config option: collect_ignore

Replaced with:
```
[tool:pytest]
addopts = --ignore=setup.py
```