### PR TITLE
Add missing package data

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -40,6 +40,9 @@ homepage = "https://github.com/{{cookiecutter.__gh_slug}}"
 [tool.setuptools]
 package-dir = {"" = "src"}
 
+[tool.setuptools.package-data]
+"*" = ["*.*"]
+
 {% if cookiecutter.command_line_interface == 'Yes' %}
 [project.scripts]
 {{cookiecutter.slug}} = "{{cookiecutter.slug}}.cli:app"


### PR DESCRIPTION
Not having this means namespaces aren't working because there are files not being added into the namespace. Which means tests inside the rendered package fails. We will address this in #735.

https://setuptools.pypa.io/en/latest/userguide/datafiles.html