### PR TITLE
Add GNU Affero General Public License

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,6 @@ replay: BAKE_OPTIONS=--replay
 replay: watch
 	;
 
+# Uses pytest-cookies; `$ pip install pytest-cookies`
 test:
 	pytest

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,6 +12,6 @@
   "add_pyup_badge": "n",
   "command_line_interface": ["Typer", "Argparse", "No command-line interface"],
   "create_author_file": "y",
-  "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
+  "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "GNU Affero General Public License", "Not open source"],
   "__gh_slug": "{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
 }

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -191,6 +191,7 @@ def test_bake_selecting_license(cookies):
         'Apache Software License 2.0':
             'Licensed under the Apache License, Version 2.0',
         'GNU General Public License v3': 'GNU GENERAL PUBLIC LICENSE',
+        'GNU Affero General Public License': 'GNU AFFERO GENERAL PUBLIC LICENSE',
     }
     for license, target_string in license_strings.items():
         with bake_in_temp_dir(

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -108,4 +108,38 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+{% elif cookiecutter.open_source_license == 'GNU Affero General Public License' -%}
+GNU AFFERO GENERAL PUBLIC LICENSE
+                      Version 3, 19 November 2007
+
+    {{ cookiecutter.project_short_description }}
+    Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.full_name }}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
 {% endif %}


### PR DESCRIPTION
Hello,

Thank you very much for this excellent repo.

The PR adds the GNU Affero General Public License to the default options for licensing. The GNU AGPL is based on the GNU GPLv3, which you already support, but adds one requirement: if a developer modifies your project and runs it on a server, they must release their source code modifications. See [Why the Affero GPL](https://www.gnu.org/licenses/why-affero-gpl.html) for more information.

Thank you for your time and considering the PR.

Regards,

@dvklopfenstein