### PR TITLE
Add __main__.py

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -10,6 +10,7 @@ if __name__ == '__main__':
 
     if 'no' in '{{ cookiecutter.command_line_interface|lower }}':
         pathlib.Path('src', '{{ cookiecutter.project_slug }}', 'cli.py').unlink()
-        
+        pathlib.Path('src', '{{ cookiecutter.project_slug }}', '__main__.py').unlink()
+
     if 'Not open source' == '{{ cookiecutter.open_source_license }}':
         pathlib.Path('LICENSE').unlink()

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 license = {text = "{{cookiecutter.open_source_license}}"}
 dependencies = [
-  {% if cookiecutter.command_line_interface.lower() == "typer" -%}
+{% if cookiecutter.command_line_interface.lower() == "typer" -%}
   "typer"
 {%- endif %}
 ]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/cli.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/cli.py
@@ -14,7 +14,7 @@ def main():
     console.print("Replace this message by putting your code into "
                "{{cookiecutter.project_slug}}.cli.main")
     console.print("See Typer documentation at https://typer.tiangolo.com/")
-    
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

on creating a python program I noticed I couldn't execute it since it didn't have a `__main__.py`.
Furthermore, I also couldn't start the debugger on that package for the very same reason.
 
This PR adds the missing `__main__.py` to the template to make it possible to both execute and debug the generated package.

I've seen [PR #481](https://github.com/audreyfeldroy/cookiecutter-pypackage/pull/481), where @znd4 already worked on a very similar PR which unfortunatelly was never merged.
Based on the coversation there, I've tried to pick up where he left.

Let me know if I'm missing anything here.


Sidenote: While adding this, I've noticed a couple things:
  - The unit tests seem to be broken.
  - When the user selects `"command_line_interface" = "Argparse`, the project still gets set up for `Typer`