### PR TITLE
Fix entry point in template's pyproject.toml

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -43,9 +43,9 @@ package-dir = {"" = "src"}
 [tool.setuptools.package-data]
 "*" = ["*.*"]
 
-{% if cookiecutter.command_line_interface == 'Yes' %}
+{% if cookiecutter.command_line_interface.lower() in ['typer', 'argparse'] %}
 [project.scripts]
-{{cookiecutter.slug}} = "{{cookiecutter.slug}}.cli:app"
+{{cookiecutter.project_slug}} = "{{cookiecutter.project_slug}}.cli:app"
 {% endif %}
 
 


### PR DESCRIPTION
Hi,

I've noticed that the entry point in `pyproject.toml` never got generated due to probably outdated code.
Therefore, the only way to call the app was via `python -m my_app`.

This PR fixes that so that after installation the user can start the application by calling `my_app` directly from command line.