### PR TITLE
Remove last mentions of Travis CI

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -12,13 +12,17 @@ on:
       - main
 jobs:
   build:
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', 'pypy3.10']
+
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up python
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -32,7 +36,7 @@ jobs:
           python -m pip install --user --upgrade build
           python -m build
       - name: Archive package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: cookie-cutter
+          name: cookie-cutter-${{ matrix.python-version }}
           path: src/dist

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -171,9 +171,8 @@ Before you submit a pull request, check that it meets these guidelines:
    new functionality into a function with a docstring, and add the feature to
    the list in README.rst.
 
-3. The pull request should work for Python 3.6 and 3.7, 3.8 and for PyPy. Check
-   https://travis-ci.org/audreyr/cookiecutter-pypackage/pull_requests and
-   make sure that the tests pass for all supported Python versions.
+3. The pull request should work for Python 3.11 and up, as well as for PyPy.
+   Tests for all these versions run in GitHub Actions on every pull request.
 
 Add a New Test
 --------------

--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,6 @@ Cookiecutter PyPackage
     :target: https://pyup.io/repos/github/audreyfeldroy/cookiecutter-pypackage/
     :alt: Updates
 
-.. image:: https://travis-ci.org/audreyfeldroy/cookiecutter-pypackage.svg?branch=master
-    :target: https://travis-ci.org/github/audreyfeldroy/cookiecutter-pypackage
-    :alt: Build Status
-
 .. image:: https://readthedocs.org/projects/cookiecutter-pypackage/badge/?version=latest
     :target: https://cookiecutter-pypackage.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
@@ -34,20 +30,6 @@ Features
 
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter
 
-Build Status
--------------
-
-Linux:
-
-.. image:: https://img.shields.io/travis/audreyfeldroy/cookiecutter-pypackage.svg
-    :target: https://travis-ci.org/audreyfeldroy/cookiecutter-pypackage
-    :alt: Linux build status on Travis CI
-
-Windows:
-
-.. image:: https://ci.appveyor.com/api/projects/status/github/audreyr/cookiecutter-pypackage?branch=master&svg=true
-    :target: https://ci.appveyor.com/project/audreyr/cookiecutter-pypackage/branch/master
-    :alt: Windows build status on Appveyor
 
 Quickstart
 ----------


### PR DESCRIPTION
Closes #707 by removing the last few references to Travis CI and Appveyor from the README and CONTRIBUTING files.
It also extends the existing GitHub Actions workflow to run tests under the three most recent CPython versions and the latest PyPy version, as described in the documentation.