### PR TITLE
Set dynamic version

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "{{cookiecutter.project_slug}}"
-version = "{{cookiecutter.version}}"
 description = "{{cookiecutter.project_short_description}}"
 readme = "README.rst"
 authors = [
@@ -22,6 +21,8 @@ dependencies = [
   "typer"
 {%- endif %}
 ]
+
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
@@ -48,6 +49,8 @@ package-dir = {"" = "src"}
 {{cookiecutter.slug}} = "{{cookiecutter.slug}}.cli:app"
 {% endif %}
 
+[tool.setuptools.dynamic]
+version = {attr = "{{cookiecutter.slug}}.__version__"}
 
 # Mypy
 # ----


### PR DESCRIPTION
This change allows versions to be set from the `__version__` attribute instead of manually defined in the pyproject config.