### PR TITLE
Add Development section to template README

### DIFF
--- a/{{cookiecutter.pypi_package_name}}/README.md
+++ b/{{cookiecutter.pypi_package_name}}/README.md
@@ -13,6 +13,33 @@
 
 * TODO
 
+## Development
+
+To set up for local development:
+
+```bash
+# Clone your fork
+git clone git@github.com:your_username/{{ cookiecutter.pypi_package_name }}.git
+cd {{ cookiecutter.pypi_package_name }}
+
+# Install in editable mode with live updates
+uv tool install --editable .
+```
+
+This installs the CLI globally but with live updates - any changes you make to the source code are immediately available when you run `{{ cookiecutter.project_slug }}`.
+
+Run tests:
+
+```bash
+uv run pytest
+```
+
+Run quality checks (format, lint, type check, test):
+
+```bash
+just qa
+```
+
 ## Credits
 
 This package was created with [Cookiecutter](https://github.com/audreyfeldroy/cookiecutter) and the [audreyfeldroy/cookiecutter-pypackage](https://github.com/audreyfeldroy/cookiecutter-pypackage) project template.


### PR DESCRIPTION
Add a Development section to the generated README.md with setup instructions for CLI tool development using `uv tool install --editable .`.

The outer CONTRIBUTING.md changes from the original PR were dropped since #888 covered that more completely.