### PR TITLE
Fix template CONTRIBUTING.md: replace obsolete toolchain references

### DIFF
--- a/{{cookiecutter.pypi_package_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.pypi_package_name}}/CONTRIBUTING.md
@@ -49,12 +49,11 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_slug }}` for 
    git clone git@github.com:your_name_here/{{ cookiecutter.project_slug }}.git
    ```
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development:
+3. Install your local copy with uv:
 
    ```sh
-   mkvirtualenv {{ cookiecutter.project_slug }}
    cd {{ cookiecutter.project_slug }}/
-   python setup.py develop
+   uv sync
    ```
 
 4. Create a branch for local development:
@@ -65,16 +64,17 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_slug }}` for 
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox:
+5. When you're done making changes, check that your changes pass linting and the tests:
 
    ```sh
-   make lint
-   make test
-   # Or
-   make test-all
+   just qa
    ```
 
-   To get flake8 and tox, just pip install them into your virtualenv.
+   Or run the tests alone:
+
+   ```sh
+   just test
+   ```
 
 6. Commit your changes and push your branch to GitHub:
 
@@ -92,14 +92,14 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
 2. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in README.md.
-3. The pull request should work for Python 3.12 and 3.13. Tests run in GitHub Actions on every pull request to the main branch, make sure that the tests pass for all supported Python versions.
+3. The pull request should work for Python 3.12, 3.13, and 3.14. Tests run in GitHub Actions on every pull request to the main branch, make sure that the tests pass for all supported Python versions.
 
 ## Tips
 
 To run a subset of tests:
 
 ```sh
-pytest tests.test_{{ cookiecutter.project_slug }}
+uv run pytest tests/
 ```
 
 ## Deploying


### PR DESCRIPTION
## Summary

- Replace virtualenvwrapper/setup.py instructions with `uv sync`
- Replace flake8/tox/make references with `just qa` and `just test`
- Add Python 3.14 to supported versions (matches template CI matrix)
- Fix test command from `pytest tests.test_...` to `uv run pytest tests/`

Fixes #885

## Test plan

- [x] `pytest tests/` passes (7/7)
- [x] Baked CONTRIBUTING.md reads correctly with updated instructions