### PR TITLE
Fix changelog URL to point to HISTORY.md

### DIFF
--- a/{{cookiecutter.pypi_package_name}}/pyproject.toml
+++ b/{{cookiecutter.pypi_package_name}}/pyproject.toml
@@ -36,7 +36,7 @@ test = [
 
 [project.urls]
 bugs = "https://github.com/{{cookiecutter.__gh_slug}}/issues"
-changelog = "https://github.com/{{cookiecutter.__gh_slug}}/blob/main/changelog.md"
+changelog = "https://github.com/{{cookiecutter.__gh_slug}}/blob/main/HISTORY.md"
 homepage = "https://github.com/{{cookiecutter.__gh_slug}}"
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- The template `pyproject.toml` had `changelog = ".../blob/main/changelog.md"`, but the actual file is `HISTORY.md`
- Updated the URL to point to the correct file

Closes #893

## Test plan
- [x] `pytest tests/` passes (14 tests)
- [x] Verified `HISTORY.md` exists in the template root