### PR TITLE
Fix template installation.md: use https:// and uv sync

### DIFF
--- a/{{cookiecutter.pypi_package_name}}/docs/installation.md
+++ b/{{cookiecutter.pypi_package_name}}/docs/installation.md
@@ -21,7 +21,7 @@ The source files for {{ cookiecutter.project_name }} can be downloaded from the 
 You can either clone the public repository:
 
 ```sh
-git clone git://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+git clone https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 ```
 
 Or download the [tarball](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/tarball/main):
@@ -34,5 +34,5 @@ Once you have a copy of the source, you can install it with:
 
 ```sh
 cd {{ cookiecutter.project_slug }}
-uv pip install .
+uv sync
 ```


### PR DESCRIPTION
## Summary
- Replace deprecated `git://` clone URL with `https://` (GitHub dropped git:// protocol support in 2021)
- Replace `uv pip install .` with `uv sync` (the generated project has `[tool.uv] package = true`)

Closes #895

## Test plan
- [x] `pytest tests/` passes (14 tests)
- [x] Verified the generated project's pyproject.toml has `[tool.uv] package = true`