### PR TITLE
Replace template test file with clean minimal version

### DIFF
--- a/{{cookiecutter.pypi_package_name}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.pypi_package_name}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -1,22 +1,8 @@
-#!/usr/bin/env python
-import pytest
-
 """Tests for `{{ cookiecutter.project_slug }}` package."""
 
-# from {{ cookiecutter.project_slug }} import {{ cookiecutter.project_slug }}
+import {{ cookiecutter.project_slug }}
 
 
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
-
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyfeldroy/cookiecutter-pypackage')
-
-
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument."""
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string
+def test_import():
+    """Verify the package can be imported."""
+    assert {{ cookiecutter.project_slug }}


### PR DESCRIPTION
## Summary
- The old test file had a misplaced docstring, a fixture returning None, and commented-out code referencing `requests` and `BeautifulSoup` (not project dependencies)
- Replaced with a clean, minimal test that imports the package and verifies it loaded
- Gives users a working starting point instead of a confusing one

Closes #897

## Test plan
- [x] `pytest tests/` passes (14 tests)
- [x] Verified the generated test file actually works after baking