### PR TITLE
Modernize outer docs: tutorial, troubleshooting, and index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,6 @@
 
 ## Getting Started
 
-- [Readme](readme.md)
 - [Tutorial](tutorial.md)
 - [PyPI Release Checklist](pypi_release_checklist.md)
 
@@ -13,9 +12,3 @@
 ## Advanced Features
 
 - [Console Script Setup](console_script_setup.md)
-
-## Indices and Tables
-
-- [General Index](#)
-- [Module Index](#)
-- [Search](#)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,13 +5,9 @@
 ## Windows Issues
 
 - Some people have reported issues using git bash; try using the Command Terminal instead.
-- Virtual environments can sometimes be tricky on Windows. If you have Python 3.6 or above installed (recommended), this should get you a virtualenv named `myenv` created inside the current folder:
+- Virtual environments can sometimes be tricky on Windows. If you have Python 3.10 or above installed (recommended), this should get you a virtualenv named `myenv` created inside the current folder:
 
     ```powershell
-    > c:\Python35\python -m venv myenv
-    ```
-    Or:
-    ```powershell
-    > c:\Python35\python c:\Python35\Tools\Scripts\pyvenv.py myenv
+    > python -m venv myenv
     ```
 - Some people have reported that they have to re-activate their virtualenv whenever they change directory, so you should remember the path to the virtualenv in case you need it.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -2,44 +2,12 @@
 
 > **Note:** Did you find any of these instructions confusing? [Edit this file](https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/main/docs/tutorial.md) and submit a pull request with your improvements!
 
-To start with, you will need a [GitHub account](https://github.com/) and an account on [PyPI](https://pypi.python.org/pypi). Create these before you get started on this tutorial. If you are new to Git and GitHub, you should probably spend a few minutes on some of the tutorials at the top of the page at [GitHub Help](https://help.github.com/).
+To start with, you will need a [GitHub account](https://github.com/) and an account on [PyPI](https://pypi.org). Create these before you get started on this tutorial. If you are new to Git and GitHub, you should probably spend a few minutes on some of the tutorials at the top of the page at [GitHub Help](https://help.github.com/).
 
-## Step 1: Install Cookiecutter
+## Step 1: Generate Your Package
 
-First, you need to create and activate a virtualenv for the package project. Use your favorite method, or create a virtualenv for your new package like this:
-
-```bash
-virtualenv ~/.virtualenvs/mypackage
-```
-
-Here, `mypackage` is the name of the package that you'll create.
-
-Activate your environment:
+Run cookiecutter-pypackage with [uvx](https://docs.astral.sh/uv/):
 
 ```bash
-source bin/activate
-```
-
-On Windows, activate it like this. You may find that using a Command Prompt window works better than gitbash.
-
-```powershell
-> \path\to\env\Scripts\activate
-```
-
-> **Note:** If you create your virtual environment folder in a different location within your project folder, be sure to add that path to your .gitignore file.
-
-Install cookiecutter:
-
-```bash
-pip install cookiecutter
-```
-
-## Step 2: Generate Your Package
-
-Now it's time to generate your Python package.
-
-Use cookiecutter, pointing it at the cookiecutter-pypackage repo:
-
-```bash
-cookiecutter https://github.com/audreyfeldroy/cookiecutter-pypackage.git
+uvx cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
 ```


### PR DESCRIPTION
## Summary
- **tutorial.md**: Replace virtualenv/pip Step 1 with single `uvx cookiecutter` command (matches the README), update PyPI URL to pypi.org
- **troubleshooting.md**: Update Python version from 3.6 to 3.10, replace `c:\Python35` paths with plain `python` command, remove deprecated `pyvenv.py` alternative
- **index.md**: Remove broken `readme.md` link (file doesn't exist in docs/), remove "Indices and Tables" section (Sphinx remnant with dead `#` links)

Closes #899

## Test plan
- [x] `pytest tests/` passes (14 tests)
- [x] Verified all remaining links in index.md point to existing files