### PR TITLE
Document GitHub Actions workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@
 ## Features
 
 *   Modern tooling: [uv](https://docs.astral.sh/uv/) for dependency management, [justfile](https://github.com/casey/just) for task running
-*   Testing with pytest, GitHub Actions for Python 3.10, 3.11, 3.12, 3.13, and 3.14
-*   Auto-release to [PyPI](https://pypi.python.org/pypi) via Trusted Publishers when you push a tag
+*   Testing with [pytest](https://docs.pytest.org/), GitHub Actions CI for Python 3.12, 3.13, and 3.14
+*   Auto-publish to [PyPI](https://pypi.org/) when you push a `v*` tag, using [Trusted Publishers](https://docs.pypi.org/trusted-publishers/) (no API tokens needed)
+*   [Hardened GitHub Actions workflows](#github-actions-workflows): SHA-pinned actions, minimal permissions, [Dependabot](https://docs.github.com/en/code-security/dependabot) for automated updates
+*   Linting with [ruff](https://docs.astral.sh/ruff/), type checking with [ty](https://docs.astral.sh/ty/)
 *   Command line interface using [Typer](https://typer.tiangolo.com/)
 
 ## Quickstart
@@ -58,6 +60,45 @@ Then:
 *   Create a GitHub repo and push your code
 *   Set up [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) for your repo
 *   Release your package by pushing a tag: `git tag v0.1.0 && git push --tags`
+
+## GitHub Actions Workflows
+
+Your generated project comes with three workflow files and a Dependabot config, all security-hardened out of the box.
+
+### CI (`ci.yml`)
+
+Runs on every push to `main` and on pull requests. Four jobs:
+
+- **Lint** - checks formatting (`ruff format --check`) and lint rules (`ruff check`)
+- **Type check** - runs [ty](https://docs.astral.sh/ty/) for static type checking
+- **Test** - runs pytest across Python 3.12, 3.13, and 3.14
+- **All checks pass** - a single status check for branch protection (uses [alls-green](https://github.com/re-actors/alls-green))
+
+You can also trigger it manually from the Actions tab (`workflow_dispatch`).
+
+### Publish (`publish.yml`)
+
+Runs when you push a tag matching `v*` (e.g., `v0.1.0`). Two jobs:
+
+1. **Build** - builds the sdist and wheel with `uv build`, uploads them as artifacts
+2. **Publish** - downloads the artifacts, generates [Sigstore build attestations](https://docs.pypi.org/attestations/), and publishes to PyPI
+
+Publishing uses [Trusted Publishers](https://docs.pypi.org/trusted-publishers/), so there are no API tokens to manage. PyPI verifies the package came from your GitHub repo's workflow via OIDC.
+
+**First-time setup:** You need to register your repo as a trusted publisher on PyPI and create a `pypi` environment in your GitHub repo settings. See [PyPI Release Checklist](docs/pypi_release_checklist.md) for the steps.
+
+### Dependabot (`dependabot.yml`)
+
+Checks weekly for newer versions of the GitHub Actions used in your workflows and opens PRs to update them. Since all actions are pinned by SHA, Dependabot is how they stay current.
+
+### Security hardening
+
+All workflows follow these practices:
+
+- **SHA-pinned actions** - every `uses:` references a full commit SHA, not a mutable tag. This prevents a compromised action from injecting code into your builds.
+- **Minimal permissions** - `permissions: {}` at the workflow level, with specific permissions granted only to jobs that need them.
+- **No persisted credentials** - `persist-credentials: false` on all checkouts, so the `GITHUB_TOKEN` isn't left in the git config after checkout.
+- **Concurrency controls** - CI cancels redundant runs on the same PR. Publish uses a concurrency group to prevent overlapping releases.
 
 ## Not Exactly What You Want?
 

--- a/docs/pypi_release_checklist.md
+++ b/docs/pypi_release_checklist.md
@@ -11,9 +11,11 @@
    - **Owner:** Your GitHub username or organization
    - **Repository name:** Your repo name
    - **Workflow name:** `publish.yml`
-   - **Environment name:** Leave blank
+   - **Environment name:** `pypi`
 
-4. Push your first tag to trigger the publish (see below).
+4. In your GitHub repo, go to Settings > Environments > New environment. Name it `pypi`. Optionally add required reviewers and restrict deployment to `v*` tags.
+
+5. Push your first tag to trigger the publish (see below).
 
 ## Every Release
 


### PR DESCRIPTION
## Summary

- Add a **GitHub Actions Workflows** section to README explaining CI, Publish, Dependabot, and security hardening
- Update the Features list to reflect current tooling (ruff, ty, Trusted Publishers, Dependabot)
- Fix release checklist: environment name is `pypi`, not blank
- Add the missing GitHub environment creation step to the release checklist

## Test plan

- [ ] Verify the README renders correctly on GitHub (anchor link from Features to the new section)
- [ ] Confirm the release checklist steps match the actual publish workflow