### PR TITLE
Add groups and aliases to just recipes

### DIFF
--- a/{{cookiecutter.pypi_package_name}}/justfile
+++ b/{{cookiecutter.pypi_package_name}}/justfile
@@ -87,7 +87,7 @@ VERSION := `uv version`
 # Print the current version of the project
 [group("release")]
 version:
-    @echo "Current version: {{VERSION}}"
+    @echo "Current version: {{ '{{VERSION}}' }}"
 
 # Tag the current version in git and put to github
 [group("release")]


### PR DESCRIPTION
This PR 
- groups the available recipes when listed for a cleaner overview
- adds aliases to commonly used tasks
- and uses `uv` to show the projects version

As this template has been quite useful and inspiring to me, I wanted to show some gratitude and make it a bit more convenient to use.