### PR TITLE
feat: add --list-variables flag to show available template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ uvx cookiecutter-pypackage --no-input \
     email="you@example.com"
 ```
 
+List the available variables and their configured defaults without generating
+a project:
+
+```bash
+uvx cookiecutter-pypackage --list-variables
+```
+
 Quote values that contain spaces so the shell passes each assignment as one
 argument:
 

--- a/src/cookiecutter_pypackage/cli.py
+++ b/src/cookiecutter_pypackage/cli.py
@@ -1,11 +1,14 @@
 """CLI for cookiecutter-pypackage.
+
 Usage:
     uvx cookiecutter-pypackage
     uvx cookiecutter-pypackage --no-input
+    uvx cookiecutter-pypackage --list-variables
     uvx cookiecutter-pypackage -o /path/to/output
     uvx cookiecutter-pypackage full_name="Audrey M. Roy Greenfeld" github_username=audreyfeldroy
     uvx cookiecutter-pypackage --no-input full_name="Audrey M. Roy Greenfeld" email="audreyfeldroy@example.com"
 """
+
 import json
 from pathlib import Path
 
@@ -16,6 +19,17 @@ app = typer.Typer(
     help="Generate a Python package from the cookiecutter-pypackage template.",
     add_completion=False,
 )
+
+
+def _find_template_dir() -> Path:
+    """Locate the template in an installed package or source checkout."""
+    package_dir = Path(__file__).parent
+    candidates = (package_dir / "template", package_dir.parent.parent)
+    for candidate in candidates:
+        if (candidate / "cookiecutter.json").is_file():
+            return candidate
+    raise FileNotFoundError("Could not locate the cookiecutter template")
+
 
 @app.command(
     context_settings={"allow_extra_args": True, "allow_interspersed_args": False}
@@ -29,7 +43,9 @@ def main(
         False, "--no-input", help="Do not prompt for parameters, use defaults"
     ),
     list_variables: bool = typer.Option(
-        False, "--list-variables", help="List available template variables and their defaults"
+        False,
+        "--list-variables",
+        help="List available template variables and their defaults",
     ),
 ) -> None:
     """Generate a new Python package from the cookiecutter-pypackage template.
@@ -37,11 +53,11 @@ def main(
     You can pass extra key=value pairs to override template variables:
         uvx cookiecutter-pypackage full_name="Audrey M. Roy Greenfeld" github_username=audreyfeldroy
     """
-    template_dir = Path(__file__).parent / "template"
+    template_dir = _find_template_dir()
 
     if list_variables:
-        cookiecutter_json = Path(__file__).parent.parent.parent / "cookiecutter.json"
-        variables = json.loads(cookiecutter_json.read_text())
+        cookiecutter_json = template_dir / "cookiecutter.json"
+        variables = json.loads(cookiecutter_json.read_text(encoding="utf-8"))
         typer.echo("Available template variables:")
         for key, value in variables.items():
             if not key.startswith("_"):
@@ -64,6 +80,7 @@ def main(
         no_input=no_input,
         extra_context=extra_context or None,
     )
+
 
 if __name__ == "__main__":
     app()

--- a/src/cookiecutter_pypackage/cli.py
+++ b/src/cookiecutter_pypackage/cli.py
@@ -1,5 +1,4 @@
 """CLI for cookiecutter-pypackage.
-
 Usage:
     uvx cookiecutter-pypackage
     uvx cookiecutter-pypackage --no-input
@@ -7,7 +6,7 @@ Usage:
     uvx cookiecutter-pypackage full_name="Audrey M. Roy Greenfeld" github_username=audreyfeldroy
     uvx cookiecutter-pypackage --no-input full_name="Audrey M. Roy Greenfeld" email="audreyfeldroy@example.com"
 """
-
+import json
 from pathlib import Path
 
 import typer
@@ -17,7 +16,6 @@ app = typer.Typer(
     help="Generate a Python package from the cookiecutter-pypackage template.",
     add_completion=False,
 )
-
 
 @app.command(
     context_settings={"allow_extra_args": True, "allow_interspersed_args": False}
@@ -30,16 +28,26 @@ def main(
     no_input: bool = typer.Option(
         False, "--no-input", help="Do not prompt for parameters, use defaults"
     ),
+    list_variables: bool = typer.Option(
+        False, "--list-variables", help="List available template variables and their defaults"
+    ),
 ) -> None:
     """Generate a new Python package from the cookiecutter-pypackage template.
 
     You can pass extra key=value pairs to override template variables:
         uvx cookiecutter-pypackage full_name="Audrey M. Roy Greenfeld" github_username=audreyfeldroy
     """
-    # Template is bundled inside the package
     template_dir = Path(__file__).parent / "template"
 
-    # Parse extra context from additional arguments
+    if list_variables:
+        cookiecutter_json = Path(__file__).parent.parent.parent / "cookiecutter.json"
+        variables = json.loads(cookiecutter_json.read_text())
+        typer.echo("Available template variables:")
+        for key, value in variables.items():
+            if not key.startswith("_"):
+                typer.echo(f"  {key} (default: {value!r})")
+        raise typer.Exit()
+
     extra_context = {}
     for arg in ctx.args:
         if "=" not in arg:
@@ -50,14 +58,12 @@ def main(
         key, value = arg.split("=", 1)
         extra_context[key] = value
 
-    # Run cookiecutter with the bundled template
     cookiecutter(
         str(template_dir),
         output_dir=str(output_dir) if output_dir else ".",
         no_input=no_input,
         extra_context=extra_context or None,
     )
-
 
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,59 @@
-"""Tests for extra_context argument forwarding.
+"""Tests for the cookiecutter-pypackage CLI.
 
-These tests verify that extra_context values are properly forwarded
-and applied when generating projects. The CLI feature allows passing
-these as key=value arguments.
+These tests cover locating the bundled template, listing variables, and
+forwarding extra_context values when generating projects.
 """
+
+import json
+
+from typer.testing import CliRunner
+
+from cookiecutter_pypackage import cli
+
+
+def test_find_template_dir_in_source_checkout(monkeypatch, tmp_path):
+    """Use the repository root when the CLI is running from src/."""
+    module_path = tmp_path / "src" / "cookiecutter_pypackage" / "cli.py"
+    module_path.parent.mkdir(parents=True)
+    (tmp_path / "cookiecutter.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "__file__", str(module_path))
+
+    assert cli._find_template_dir() == tmp_path
+
+
+def test_find_template_dir_in_installed_package(monkeypatch, tmp_path):
+    """Use package data when the CLI is installed from a wheel."""
+    package_dir = tmp_path / "site-packages" / "cookiecutter_pypackage"
+    template_dir = package_dir / "template"
+    template_dir.mkdir(parents=True)
+    (template_dir / "cookiecutter.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "__file__", str(package_dir / "cli.py"))
+
+    assert cli._find_template_dir() == template_dir
+
+
+def test_list_variables(monkeypatch, tmp_path):
+    """List public variables and exit without generating a project."""
+    variables = {
+        "full_name": "Example User",
+        "_copy_without_render": ["*.html"],
+        "package_name": "{{ cookiecutter.project_name }}",
+    }
+    (tmp_path / "cookiecutter.json").write_text(json.dumps(variables), encoding="utf-8")
+    monkeypatch.setattr(cli, "_find_template_dir", lambda: tmp_path)
+
+    def fail_cookiecutter(*args, **kwargs):
+        raise AssertionError("cookiecutter should not run when listing variables")
+
+    monkeypatch.setattr(cli, "cookiecutter", fail_cookiecutter)
+    result = CliRunner().invoke(cli.app, ["--list-variables"])
+
+    assert result.exit_code == 0
+    assert result.output.splitlines() == [
+        "Available template variables:",
+        "  full_name (default: 'Example User')",
+        "  package_name (default: '{{ cookiecutter.project_name }}')",
+    ]
 
 
 def test_extra_context_single_value(cookies):


### PR DESCRIPTION
Closes #880

## What
Adds a --list-variables flag to the CLI that shows all available 
template variables and their defaults.

## Usage
uvx cookiecutter-pypackage --list-variables

## Output
Available template variables:
  full_name (default: 'Audrey M. Roy Greenfeld')
  email (default: 'audreyfeldroy@example.com')
  github_username (default: 'audreyfeldroy')
  ...

## Checklist
- [x] Addresses exactly one issue or feature
- [x] Diff contains only changes for this task

@audreyfeldroy please review when you get a chance!