### PR TITLE
Document CLI template-variable overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,41 @@ cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
 
 </details>
 
+## Advanced Usage: Overriding Template Variables from the CLI
+
+You can override any template variable by passing `key=value` arguments. Any
+variable you don't pass uses the default from `cookiecutter.json`.
+
+Shell quoting matters when values contain spaces:
+
+```bash
+full_name="First Last"   # correct
+full_name=First Last      # wrong, shell splits this
+```
+
+**Fully non-interactive** (no prompts at all):
+
+```bash
+uvx cookiecutter-pypackage --no-input \
+    pypi_package_name="my-package" \
+    full_name="First Last" \
+    github_username="janedoe" \
+    email="jane@example.com"
+```
+
+`project_slug` is derived from `pypi_package_name`, so you usually don't need to
+set it explicitly.
+
+**Override some variables** (still prompts for the rest):
+
+```bash
+uvx cookiecutter-pypackage \
+    pypi_package_name="my-package" \
+    github_username="janedoe"
+```
+
+All available variables and their defaults are in [`cookiecutter.json`](cookiecutter.json).
+
 ## Documentation
 
 **[audreyfeldroy.github.io/cookiecutter-pypackage](https://audreyfeldroy.github.io/cookiecutter-pypackage/)**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ uvx cookiecutter-pypackage \
 
 For non-interactive automation, add `--no-input` before the overrides.
 Variables you don't pass use the defaults in
-[`cookiecutter.json`](cookiecutter.json):
+[`cookiecutter.json`](https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/main/cookiecutter.json):
 
 ```bash
 uvx cookiecutter-pypackage --no-input \

--- a/README.md
+++ b/README.md
@@ -60,40 +60,37 @@ cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
 
 </details>
 
-## Advanced Usage: Overriding Template Variables from the CLI
+## Override template variables
 
-You can override any template variable by passing `key=value` arguments. Any
-variable you don't pass uses the default from `cookiecutter.json`.
-
-Shell quoting matters when values contain spaces:
-
-```bash
-full_name="First Last"   # correct
-full_name=First Last      # wrong, shell splits this
-```
-
-**Fully non-interactive** (no prompts at all):
-
-```bash
-uvx cookiecutter-pypackage --no-input \
-    pypi_package_name="my-package" \
-    full_name="First Last" \
-    github_username="janedoe" \
-    email="jane@example.com"
-```
-
-`project_slug` is derived from `pypi_package_name`, so you usually don't need to
-set it explicitly.
-
-**Override some variables** (still prompts for the rest):
+Pass `key=value` arguments to prefill the interactive prompts. You can still
+review or change each value:
 
 ```bash
 uvx cookiecutter-pypackage \
-    pypi_package_name="my-package" \
-    github_username="janedoe"
+    full_name="Your Name" \
+    github_username=yourhandle
 ```
 
-All available variables and their defaults are in [`cookiecutter.json`](cookiecutter.json).
+For non-interactive automation, add `--no-input` before the overrides.
+Variables you don't pass use the defaults in
+[`cookiecutter.json`](cookiecutter.json):
+
+```bash
+uvx cookiecutter-pypackage --no-input \
+    full_name="Your Name" \
+    email="you@example.com"
+```
+
+Quote values that contain spaces so the shell passes each assignment as one
+argument:
+
+```bash
+full_name="First Last"  # correct
+full_name=First Last    # incorrect
+```
+
+See the [template prompts](https://audreyfeldroy.github.io/cookiecutter-pypackage/prompts/)
+for descriptions of all available variables.
 
 ## Documentation
 


### PR DESCRIPTION
Closes #879

## What

Document how `key=value` arguments prefill interactive prompts, how `--no-input` enables automation, why shell quoting matters, and where to find the current variable list.

This is the rebased replacement for #907. The original documentation work remains authored by @klouds27. The current-variable examples and concise presentation incorporate ideas from #929 and #930 by @iamamystery, whose contribution is recorded with a `Co-authored-by` trailer.

## Why a replacement PR

PR #907 needed rebasing onto current `main`. Although that PR allows maintainer edits, GitHub rejected authenticated pushes to the contributor fork branch over both HTTPS and SSH. Per the repository maintenance policy, this origin-hosted branch preserves the contributor authorship while allowing the rebased work to proceed.

The unrelated Ruff invocation change from #930 is intentionally excluded.

## Validation

- `git diff --check`
- Ruff formatting and lint checks
- ty
- 20 pytest tests
- documentation build
- wheel build
- installed-wheel smoke test using the documented `--no-input` values
- independent audits for CLI accuracy, documentation clarity, and attribution safety

## AI Provenance

- **Tool:** Codex
- **Model:** GPT-5
- **Prompt/thread:** Maintainer-directed task to rebase and update #907 with independent review agents

## Checklist

- [x] Addresses exactly one issue or feature
- [x] Documentation examples were validated against installed behavior
- [x] Diff contains only changes for this task
