### PR TITLE
Make GitHub setup opt-in and harden generated-project setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -38,6 +40,8 @@ jobs:
   type-check:
     name: Type check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -51,6 +55,8 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +82,8 @@ jobs:
     name: Coverage
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,11 @@ permissions: {}
 jobs:
   analyze:
     name: Analyze
+    if: ${{ github.event.repository.private == false || vars.CODE_SECURITY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,6 +22,8 @@ jobs:
     name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,4 +33,5 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
         with:
+          advanced-security: ${{ github.event.repository.private == false || vars.CODE_SECURITY_ENABLED == 'true' }}
           inputs: ./.github/

--- a/CHANGELOG/0.6.0.md
+++ b/CHANGELOG/0.6.0.md
@@ -49,7 +49,7 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **From prompt to pushed repository—with you in control.** GitHub setup defaults to no. If you opt in, visibility defaults to private and the generator shows every planned action before asking for final confirmation. It then creates the repository under the selected owner, initializes Git, makes a descriptive first commit, and pushes `main`.
 
-- **GitHub Pages ready from the first push.** The generator configures Pages to deploy through GitHub Actions, allowing the included documentation workflow to publish the Zensical site without a separate repository-settings visit.
+- **GitHub Pages ready from the first push—when you want it.** Public repositories enable Pages by default. Private repositories leave it off unless you separately accept a warning that the site can still be public and that private-repository Pages may require a paid plan.
 
 - **PyPI trusted-publishing setup with fewer detours.** Confirmed GitHub setups create a `pypi` environment before the first push, and the generator prints the exact owner, repository, workflow, environment, and package values needed to register a pending publisher on PyPI.
 
@@ -65,7 +65,7 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **CLI overrides are documented for interactive and automated use.** The README explains `key=value` overrides, `--no-input`, shell quoting, and how to discover the authoritative variable list. ([#932](https://github.com/audreyfeldroy/cookiecutter-pypackage/pull/932))
 
-- **Explicit GitHub automation.** Non-interactive generation skips GitHub by default. Automation can opt in intentionally with `--github private` or `--github public`, while `--github skip` suppresses the setup question during interactive runs.
+- **Explicit, detectable GitHub automation.** Non-interactive generation skips GitHub by default. Automation can opt in intentionally with `--github private` or `--github public`, while `--github skip` suppresses the setup question during interactive runs. Public automation enables Pages; private automation leaves it disabled. Requested setup failures exit nonzero and preserve the generated directory for recovery.
 
 - **A cleaner first commit.** The generated commit records the package, tests, documentation, workflows, project policies, release tooling, and configuration included in the scaffold, giving the new repository a useful starting history.
 
@@ -73,7 +73,7 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **Refreshed workflow foundations.** The generated and template-repository workflows use updated SHA-pinned releases of setup-uv, CodeQL, Pages configuration, artifact handling, and zizmor.
 
-If GitHub CLI is unavailable, unauthenticated, declined, or unable to complete setup, generation still succeeds locally without creating a Git commit. Existing nonempty repositories are never modified automatically.
+Declining or cancelling before final confirmation leaves only the generated project files—no Git commit or remote repository. After confirmation, a command failure can leave a clearly reported, recoverable partial state such as a local commit or an empty remote repository. The command exits nonzero and keeps the generated directory. Existing nonempty repositories are never modified automatically.
 
 ### Contributors
 

--- a/CHANGELOG/0.6.0.md
+++ b/CHANGELOG/0.6.0.md
@@ -47,7 +47,7 @@ These changes affect future generation commands and custom contexts only. Projec
 
 ### What's new
 
-- **From prompt to pushed repository—with you in control.** GitHub setup defaults to no. If you opt in, visibility defaults to private and the generator shows every planned action before asking for final confirmation. It then creates the repository under the selected owner, initializes Git, makes a descriptive first commit, and pushes `main`.
+- **From prompt to pushed repository—with you in control.** GitHub setup defaults to no. If you opt in, visibility defaults to private and the generator shows every planned action before asking for final confirmation. It then creates the repository under the selected owner, initializes Git, makes a descriptive first commit, and pushes `main` using the SSH or HTTPS transport already configured in GitHub CLI.
 
 - **GitHub Pages ready from the first push—when you want it.** Public repositories enable Pages by default. Private repositories leave it off unless you separately accept a warning that the site can still be public and that private-repository Pages may require a paid plan.
 

--- a/CHANGELOG/0.6.0.md
+++ b/CHANGELOG/0.6.0.md
@@ -49,7 +49,7 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **From prompt to pushed repository—with you in control.** GitHub setup defaults to no. If you opt in, visibility defaults to private and the generator shows every planned action before asking for final confirmation. It then creates the repository under the selected owner, initializes Git, makes a descriptive first commit, and pushes `main` using the SSH or HTTPS transport already configured in GitHub CLI.
 
-- **GitHub Pages ready from the first push—when you want it.** Public repositories enable Pages by default. Private repositories leave it off unless you separately accept a warning that the site can still be public and that private-repository Pages may require a paid plan.
+- **GitHub Pages ready from the first push—when you want it.** Public repositories enable Pages and documentation deployment by default. Private repositories leave both off unless you separately accept a warning that the site can still be public and that private-repository Pages may require a paid plan. When Pages stays off, the docs workflow stays quietly paused instead of turning the first push red.
 
 - **PyPI trusted-publishing setup with fewer detours.** Confirmed GitHub setups create a `pypi` environment before the first push, and the generator prints the exact owner, repository, workflow, environment, and package values needed to register a pending publisher on PyPI.
 

--- a/CHANGELOG/0.6.0.md
+++ b/CHANGELOG/0.6.0.md
@@ -71,6 +71,8 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **A verified starter project.** Generated packages pass Ruff and pytest out of the box, use consistent test discovery, and target Python 3.12, 3.13, and 3.14 across their local and CI workflows.
 
+- **Private repositories start cleanly.** Checkout permissions are granted only to the jobs that need them. CodeQL waits for an explicit `CODE_SECURITY_ENABLED=true` opt-in on private repositories, while zizmor keeps auditing in its workflow log without requiring a paid GitHub Code Security feature.
+
 - **Refreshed workflow foundations.** The generated and template-repository workflows use updated SHA-pinned releases of setup-uv, CodeQL, Pages configuration, artifact handling, and zizmor.
 
 Declining or cancelling before final confirmation leaves only the generated project files—no Git commit or remote repository. After confirmation, a command failure can leave a clearly reported, recoverable partial state such as a local commit or an empty remote repository. The package CLI and documented direct Cookiecutter command exit nonzero and keep the generated directory. Existing nonempty repositories are never modified automatically.

--- a/CHANGELOG/0.6.0.md
+++ b/CHANGELOG/0.6.0.md
@@ -1,0 +1,82 @@
+# Cookiecutter PyPackage 0.6.0: From prompt to GitHub in one run
+
+Creating a package should leave you with a real project, not a local directory followed by a setup checklist. When you opt in, Cookiecutter PyPackage 0.6.0 can create your GitHub repository, configure its documentation and publishing environment, make the initial commit, and push it—all during project generation.
+
+```bash
+uv tool upgrade cookiecutter-pypackage
+```
+
+### Before you upgrade: renamed template variables
+
+Version 0.6.0 gives the project's human-readable name, PyPI package name, Python import name, and GitHub owner distinct roles.
+
+If you automate project generation or maintain a custom Cookiecutter context, update these variables:
+
+| Before 0.6.0 | From 0.6.0 | Used for |
+|---|---|---|
+| `pypi_package_name` | `package_name` | PyPI package, GitHub repository, and generated directory |
+| `project_slug` | `import_name` | Python imports and the generated CLI command |
+| GitHub owner inferred from `github_username` | `github_repo_owner` | Personal or organization-owned repositories |
+
+For example:
+
+```bash
+# Before
+uvx cookiecutter-pypackage --no-input \
+    pypi_package_name=my-package \
+    project_slug=my_package
+
+# From 0.6.0
+uvx cookiecutter-pypackage --no-input \
+    package_name=my-package \
+    import_name=my_package
+```
+
+`github_repo_owner` defaults to `github_username`, so personal projects require no extra configuration. Set it explicitly when the repository belongs to an organization:
+
+```bash
+uvx cookiecutter-pypackage --no-input \
+    github_username=yourhandle \
+    github_repo_owner=your-organization \
+    project_name="My Package"
+```
+
+Custom forks that referenced the private `__gh_slug` variable should construct the repository path from `github_repo_owner` and `package_name` instead.
+
+These changes affect future generation commands and custom contexts only. Projects you have already generated are not renamed or modified.
+
+### What's new
+
+- **From prompt to pushed repository—with you in control.** GitHub setup defaults to no. If you opt in, visibility defaults to private and the generator shows every planned action before asking for final confirmation. It then creates the repository under the selected owner, initializes Git, makes a descriptive first commit, and pushes `main`.
+
+- **GitHub Pages ready from the first push.** The generator configures Pages to deploy through GitHub Actions, allowing the included documentation workflow to publish the Zensical site without a separate repository-settings visit.
+
+- **PyPI trusted-publishing setup with fewer detours.** Confirmed GitHub setups create a `pypi` environment before the first push, and the generator prints the exact owner, repository, workflow, environment, and package values needed to register a pending publisher on PyPI.
+
+- **See every template variable before generating.** Run `uvx cookiecutter-pypackage --list-variables` to inspect the current variables and their defaults—particularly useful when building scripts or non-interactive workflows. Thanks [@iamamystery](https://github.com/iamamystery)! ([#931](https://github.com/audreyfeldroy/cookiecutter-pypackage/pull/931))
+
+- **A meaningful first changelog entry.** Every generated project starts with `CHANGELOG/<first_version>.md`, describing the scaffold it received and providing a useful starting point for its first GitHub Release.
+
+### What's better
+
+- **Names that match how Python projects work.** `project_name` is for people, `package_name` is for PyPI and GitHub, and `import_name` is for Python. Package and import names are derived automatically in the common case, while remaining independently customizable.
+
+- **Organization-owned repositories are first-class.** Your personal attribution can remain tied to `github_username` while repository URLs, documentation, security reporting, and automation use `github_repo_owner`.
+
+- **CLI overrides are documented for interactive and automated use.** The README explains `key=value` overrides, `--no-input`, shell quoting, and how to discover the authoritative variable list. ([#932](https://github.com/audreyfeldroy/cookiecutter-pypackage/pull/932))
+
+- **Explicit GitHub automation.** Non-interactive generation skips GitHub by default. Automation can opt in intentionally with `--github private` or `--github public`, while `--github skip` suppresses the setup question during interactive runs.
+
+- **A cleaner first commit.** The generated commit records the package, tests, documentation, workflows, project policies, release tooling, and configuration included in the scaffold, giving the new repository a useful starting history.
+
+- **A verified starter project.** Generated packages pass Ruff and pytest out of the box, use consistent test discovery, and target Python 3.12, 3.13, and 3.14 across their local and CI workflows.
+
+- **Refreshed workflow foundations.** The generated and template-repository workflows use updated SHA-pinned releases of setup-uv, CodeQL, Pages configuration, artifact handling, and zizmor.
+
+If GitHub CLI is unavailable, unauthenticated, declined, or unable to complete setup, generation still succeeds locally without creating a Git commit. Existing nonempty repositories are never modified automatically.
+
+### Contributors
+
+[@audreyfeldroy](https://github.com/audreyfeldroy) ([Audrey M. Roy Greenfeld](https://audrey.feldroy.com/)) designed and built the GitHub launch flow, repository-owner model, generated changelog, first-commit experience, and streamlined onboarding documentation.
+
+Thanks to [@iamamystery](https://github.com/iamamystery) (Muhammad Jawad) for adding template-variable discovery and helping shape the CLI examples, and to [@klouds27](https://github.com/klouds27) for the original documentation of `key=value` overrides.

--- a/CHANGELOG/0.6.0.md
+++ b/CHANGELOG/0.6.0.md
@@ -73,7 +73,7 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **Refreshed workflow foundations.** The generated and template-repository workflows use updated SHA-pinned releases of setup-uv, CodeQL, Pages configuration, artifact handling, and zizmor.
 
-Declining or cancelling before final confirmation leaves only the generated project files—no Git commit or remote repository. After confirmation, a command failure can leave a clearly reported, recoverable partial state such as a local commit or an empty remote repository. The command exits nonzero and keeps the generated directory. Existing nonempty repositories are never modified automatically.
+Declining or cancelling before final confirmation leaves only the generated project files—no Git commit or remote repository. After confirmation, a command failure can leave a clearly reported, recoverable partial state such as a local commit or an empty remote repository. The package CLI and documented direct Cookiecutter command exit nonzero and keep the generated directory. Existing nonempty repositories are never modified automatically.
 
 ### Contributors
 

--- a/CHANGELOG/unreleased.md
+++ b/CHANGELOG/unreleased.md
@@ -1,18 +1,17 @@
-# Cookiecutter PyPackage 0.6.0: From prompt to GitHub in one run
+# Unreleased
 
-Creating a package should leave you with a real project, not a local directory followed by a setup checklist. When you opt in, Cookiecutter PyPackage 0.6.0 can create your GitHub repository, configure its documentation and publishing environment, make the initial commit, and push it—all during project generation.
+This file records user-visible changes since Cookiecutter PyPackage 0.5.0. It
+is not a release announcement; finalize it as `CHANGELOG/X.Y.Z.md` during
+release preparation.
 
-```bash
-uv tool upgrade cookiecutter-pypackage
-```
+### Migration for the next release: renamed template variables
 
-### Before you upgrade: renamed template variables
-
-Version 0.6.0 gives the project's human-readable name, PyPI package name, Python import name, and GitHub owner distinct roles.
+The next release gives the project's human-readable name, PyPI package name,
+Python import name, and GitHub owner distinct roles.
 
 If you automate project generation or maintain a custom Cookiecutter context, update these variables:
 
-| Before 0.6.0 | From 0.6.0 | Used for |
+| Before | Next release | Used for |
 |---|---|---|
 | `pypi_package_name` | `package_name` | PyPI package, GitHub repository, and generated directory |
 | `project_slug` | `import_name` | Python imports and the generated CLI command |
@@ -26,7 +25,7 @@ uvx cookiecutter-pypackage --no-input \
     pypi_package_name=my-package \
     project_slug=my_package
 
-# From 0.6.0
+# Next release
 uvx cookiecutter-pypackage --no-input \
     package_name=my-package \
     import_name=my_package
@@ -55,7 +54,9 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **See every template variable before generating.** Run `uvx cookiecutter-pypackage --list-variables` to inspect the current variables and their defaults—particularly useful when building scripts or non-interactive workflows. Thanks [@iamamystery](https://github.com/iamamystery)! ([#931](https://github.com/audreyfeldroy/cookiecutter-pypackage/pull/931))
 
-- **A meaningful first changelog entry.** Every generated project starts with `CHANGELOG/<first_version>.md`, describing the scaffold it received and providing a useful starting point for its first GitHub Release.
+- **A meaningful first changelog entry.** Every generated project starts with
+  `CHANGELOG/<first_version>.md`, describing the scaffold it received and
+  providing a useful starting point for its first GitHub Release.
 
 ### What's better
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ repository, makes the first Git commit, creates the `pypi` environment, and
 pushes `main`. Public repositories enable Pages by default. For private
 repositories, Pages defaults to off because
 [the site can still be public](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
-and the feature may require a paid GitHub plan.
+and the feature may require a paid GitHub plan. The docs deployment workflow
+follows that choice, so declining Pages does not create a failed workflow on
+the first push.
 
 <details>
 <summary>Without uvx</summary>
@@ -102,10 +104,10 @@ uvx cookiecutter-pypackage --no-input --github private \
     package_name=my-package
 ```
 
-`--github public` also enables Pages. `--github private` leaves Pages disabled;
-run interactively if you want to acknowledge the visibility warning and enable
-it. If requested GitHub setup fails, the command exits nonzero and keeps the
-generated directory for recovery.
+`--github public` also enables Pages and docs deployment. `--github private`
+leaves both disabled; run interactively if you want to acknowledge the
+visibility warning and enable them. If requested GitHub setup fails, the
+command exits nonzero and keeps the generated directory for recovery.
 
 Use `--github skip` to suppress the GitHub question during an interactive
 generation.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ uvx cookiecutter-pypackage
 | Type checking | [ty](https://docs.astral.sh/ty/) | All rules enabled, watch mode with `just type-check-watch` |
 | Testing | [pytest](https://docs.pytest.org/) | Python 3.12, 3.13, 3.14 |
 | CLI framework | [Typer](https://typer.tiangolo.com/) | Entry point + `__main__.py` included |
-| Docs | [Zensical](https://zensical.org/) + [mkdocstrings](https://mkdocstrings.github.io/) | Auto-deployed to GitHub Pages, API docs from docstrings |
+| Docs | [Zensical](https://zensical.org/) + [mkdocstrings](https://mkdocstrings.github.io/) | GitHub Pages deployment, API docs from docstrings |
 
 ### CI/CD (GitHub Actions, [security-hardened](https://audreyfeldroy.github.io/cookiecutter-pypackage/github_actions/))
 
@@ -54,8 +54,11 @@ to generate, verify, and release your package.
 After the template prompts, you can optionally set up GitHub. The default is
 **no**: pressing Enter creates only the project files. If you opt in, the
 generator shows its complete plan before it creates a private or public
-repository, makes the first Git commit, pushes `main`, enables Pages, and
-creates the `pypi` environment.
+repository, makes the first Git commit, creates the `pypi` environment, and
+pushes `main`. Public repositories enable Pages by default. For private
+repositories, Pages defaults to off because
+[the site can still be public](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
+and the feature may require a paid GitHub plan.
 
 <details>
 <summary>Without uvx</summary>
@@ -98,6 +101,11 @@ uvx cookiecutter-pypackage --no-input --github private \
     project_name="My Package" \
     package_name=my-package
 ```
+
+`--github public` also enables Pages. `--github private` leaves Pages disabled;
+run interactively if you want to acknowledge the visibility warning and enable
+it. If requested GitHub setup fails, the command exits nonzero and keeps the
+generated directory for recovery.
 
 Use `--github skip` to suppress the GitHub question during an interactive
 generation.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ private or public repository:
 
 ```bash
 uvx cookiecutter-pypackage --no-input --github private \
+    full_name="Your Name" \
+    email="you@example.com" \
+    github_username=yourhandle \
+    author_website="" \
     project_name="My Package" \
     package_name=my-package
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ and the feature may require a paid GitHub plan.
 uv venv
 source .venv/bin/activate
 uv pip install cookiecutter
-cookiecutter gh:audreyfeldroy/cookiecutter-pypackage
+cookiecutter --keep-project-on-failure gh:audreyfeldroy/cookiecutter-pypackage
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,16 @@ Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then:
 uvx cookiecutter-pypackage
 ```
 
-You'll be prompted for your package name, GitHub username, and a few other values ([full list](https://audreyfeldroy.github.io/cookiecutter-pypackage/prompts/)). Then push to GitHub and follow the [tutorial](https://audreyfeldroy.github.io/cookiecutter-pypackage/tutorial/) to enable Pages and set up PyPI publishing.
+You'll be prompted for your package name, GitHub username, and a few other
+values ([full list](https://audreyfeldroy.github.io/cookiecutter-pypackage/prompts/)).
+Follow the [tutorial](https://audreyfeldroy.github.io/cookiecutter-pypackage/tutorial/)
+to generate, verify, and release your package.
+
+After the template prompts, you can optionally set up GitHub. The default is
+**no**: pressing Enter creates only the project files. If you opt in, the
+generator shows its complete plan before it creates a private or public
+repository, makes the first Git commit, pushes `main`, enables Pages, and
+creates the `pypi` environment.
 
 <details>
 <summary>Without uvx</summary>
@@ -80,6 +89,18 @@ uvx cookiecutter-pypackage --no-input \
     full_name="Your Name" \
     email="you@example.com"
 ```
+
+Non-interactive generation skips GitHub setup unless you explicitly request a
+private or public repository:
+
+```bash
+uvx cookiecutter-pypackage --no-input --github private \
+    project_name="My Package" \
+    package_name=my-package
+```
+
+Use `--github skip` to suppress the GitHub question during an interactive
+generation.
 
 List the available variables and their configured defaults without generating
 a project:

--- a/docs/github_actions.md
+++ b/docs/github_actions.md
@@ -44,15 +44,29 @@ If Pages was not enabled, go to Settings > Pages and set the source to
 
 ## CodeQL (`codeql.yml`)
 
-Runs on pushes to `main`, pull requests, and a weekly schedule. Uses GitHub's [CodeQL](https://codeql.github.com/) engine with the `security-extended` query suite, which adds medium-precision security checks (taint tracking, injection detection) on top of the default high-precision set. Results appear in your repo's Security > Code scanning tab.
+Runs on pushes to `main`, pull requests, and a weekly schedule for public
+repositories. Uses GitHub's [CodeQL](https://codeql.github.com/) engine with the
+`security-extended` query suite, which adds medium-precision security checks
+(taint tracking, injection detection) on top of the default high-precision set.
+Results appear in your repo's Security > Code scanning tab.
 
 CodeQL does dataflow analysis that linters can't: it traces user input across function calls and files to find SQL injection, command injection, SSRF, path traversal, and similar vulnerabilities.
+
+Private and internal repositories skip this job by default because CodeQL
+requires GitHub Code Security there. After enabling Code Security in
+**Settings > Advanced Security**, create the repository Actions variable
+`CODE_SECURITY_ENABLED` with the value `true` to run CodeQL and upload zizmor
+results.
 
 If your package includes compiled code, the workflow has inline comments showing how to add `c-cpp`, `go`, `java-kotlin`, or `swift` and switch to `autobuild`.
 
 ## Zizmor (`zizmor.yml`)
 
 Runs on pushes and pull requests that touch `.github/workflows/`. [Zizmor](https://woodruffw.github.io/zizmor/) audits your GitHub Actions workflows for security issues: excessive permissions, unpinned actions, credential exposure, cache poisoning risks, and other patterns that tools like CodeQL don't cover (since CodeQL analyzes your code, not your CI configuration).
+
+Zizmor still runs for private repositories without GitHub Code Security and
+prints its findings in the workflow log. Setting `CODE_SECURITY_ENABLED=true`
+after enabling Code Security also uploads those findings to code scanning.
 
 ## Dependabot (`dependabot.yml`)
 

--- a/docs/github_actions.md
+++ b/docs/github_actions.md
@@ -23,7 +23,11 @@ Runs when you push a tag matching `v*` (e.g., `v0.1.0`). Two jobs:
 
 Publishing uses [Trusted Publishers](https://docs.pypi.org/trusted-publishers/), so there are no API tokens to manage. PyPI verifies the package came from your GitHub repo's workflow via OIDC.
 
-**First-time setup:** The post-generation hook creates the `pypi` environment automatically. You still need to register your repo as a trusted publisher on PyPI. See [PyPI Release Checklist](pypi_release_checklist.md) for the steps.
+**First-time setup:** If you opt into GitHub setup, the post-generation hook
+attempts to create the `pypi` environment before the first push. If you skip
+setup or that step fails, create the environment manually. You still need to
+register your repo as a trusted publisher on PyPI. See
+[PyPI Release Checklist](pypi_release_checklist.md) for the steps.
 
 ## Documentation (`docs.yml`)
 
@@ -32,7 +36,11 @@ Runs on push to `main`. Two jobs:
 1. **Build** - builds the documentation site with `zensical build`
 2. **Deploy** - deploys to GitHub Pages
 
-**First-time setup:** The post-generation hook configures this automatically. If it couldn't (no `gh` CLI or repo not yet created), go to Settings > Pages and set the source to **GitHub Actions**.
+**First-time setup:** Public GitHub setup enables Pages by default. Private
+setup asks separately and defaults to off because a Pages site can be public
+even when its repository is private, and the feature may require a paid plan.
+If Pages was not enabled, go to Settings > Pages and set the source to
+**GitHub Actions** after reviewing those visibility implications.
 
 ## CodeQL (`codeql.yml`)
 

--- a/docs/github_actions.md
+++ b/docs/github_actions.md
@@ -31,7 +31,8 @@ register your repo as a trusted publisher on PyPI. See
 
 ## Documentation (`docs.yml`)
 
-Runs on push to `main`. Two jobs:
+Runs on push to `main` when the repository variable
+`DOCS_DEPLOYMENT_ENABLED` is `true`. Two jobs:
 
 1. **Build** - builds the documentation site with `zensical build`
 2. **Deploy** - deploys to GitHub Pages
@@ -39,8 +40,19 @@ Runs on push to `main`. Two jobs:
 **First-time setup:** Public GitHub setup enables Pages by default. Private
 setup asks separately and defaults to off because a Pages site can be public
 even when its repository is private, and the feature may require a paid plan.
-If Pages was not enabled, go to Settings > Pages and set the source to
-**GitHub Actions** after reviewing those visibility implications.
+The generator sets `DOCS_DEPLOYMENT_ENABLED` to match that choice, so the
+workflow stays paused instead of failing when Pages is off.
+
+To enable deployment later, review those visibility implications, go to
+**Settings > Pages**, set the source to **GitHub Actions**, then set the
+repository variable:
+
+```bash
+gh variable set DOCS_DEPLOYMENT_ENABLED --repo OWNER/REPOSITORY --body true
+```
+
+Local preview and `just docs-build` work regardless of this deployment
+setting.
 
 ## CodeQL (`codeql.yml`)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ Answer a few [prompts](prompts.md) and you'll have a complete project: source co
 **A documentation site ready to deploy.** [Zensical](https://zensical.org/)
 builds your docs with the Material theme, light and dark mode, and
 [mkdocstrings](https://mkdocstrings.github.io/) generates API reference pages
-from your docstrings. Once you enable GitHub Pages, a push to `main` publishes
+from your docstrings. Once you enable GitHub Pages and set
+`DOCS_DEPLOYMENT_ENABLED=true`, a push to `main` publishes
 the site. Preview locally with `just docs-serve`.
 
 **Automated PyPI publishing with no tokens to manage.** Push a `v*` tag and GitHub Actions builds your package, signs it with [Sigstore](https://docs.pypi.org/attestations/), and publishes via [Trusted Publishers](https://docs.pypi.org/trusted-publishers/). OIDC handles authentication, so there are no API tokens to create, rotate, or leak.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,11 @@ Answer a few [prompts](prompts.md) and you'll have a complete project: source co
 
 **A real development workflow.** [uv](https://docs.astral.sh/uv/) manages your dependencies and virtual environments. [just](https://github.com/casey/just) gives you one command for everything: `just qa` formats your code with [ruff](https://docs.astral.sh/ruff/), lints it, type-checks with [ty](https://docs.astral.sh/ty/), and runs your [pytest](https://docs.pytest.org/) suite across Python 3.12, 3.13, and 3.14. A [Typer](https://typer.tiangolo.com/) CLI is wired up and working from the first `uv sync`.
 
-**A documentation site that deploys itself.** [Zensical](https://zensical.org/) builds your docs with the Material theme, light and dark mode, and [mkdocstrings](https://mkdocstrings.github.io/) generates API reference pages from your docstrings. Push to main and it's live on GitHub Pages. Preview locally with `just docs-serve`.
+**A documentation site ready to deploy.** [Zensical](https://zensical.org/)
+builds your docs with the Material theme, light and dark mode, and
+[mkdocstrings](https://mkdocstrings.github.io/) generates API reference pages
+from your docstrings. Once you enable GitHub Pages, a push to `main` publishes
+the site. Preview locally with `just docs-serve`.
 
 **Automated PyPI publishing with no tokens to manage.** Push a `v*` tag and GitHub Actions builds your package, signs it with [Sigstore](https://docs.pypi.org/attestations/), and publishes via [Trusted Publishers](https://docs.pypi.org/trusted-publishers/). OIDC handles authentication, so there are no API tokens to create, rotate, or leak.
 

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -95,7 +95,9 @@ Public GitHub setup enables Pages by default. Private setup asks separately and
 defaults to off because the resulting site can still be public and the feature
 may require a paid GitHub plan. If Pages was not enabled, review those
 visibility implications, then go to your repository's Settings > Pages and set
-the source to **GitHub Actions**.
+the source to **GitHub Actions**. Finally, set the repository variable
+`DOCS_DEPLOYMENT_ENABLED` to `true`; until then, the deployment workflow stays
+paused and local docs commands continue to work.
 
 ## Configuration (`pyproject.toml`)
 

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -91,7 +91,11 @@ The docs site is built with [Zensical](https://zensical.org/) and configured in 
 
 The API reference page (`docs/api.md`) auto-generates documentation from your docstrings using [mkdocstrings](https://mkdocstrings.github.io/). Write docstrings in your code and they'll appear on the docs site automatically.
 
-The post-generation hook enables GitHub Pages automatically. If it couldn't, go to your repo's Settings > Pages and set the source to **GitHub Actions**.
+Public GitHub setup enables Pages by default. Private setup asks separately and
+defaults to off because the resulting site can still be public and the feature
+may require a paid GitHub plan. If Pages was not enabled, review those
+visibility implications, then go to your repository's Settings > Pages and set
+the source to **GitHub Actions**.
 
 ## Configuration (`pyproject.toml`)
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -52,3 +52,7 @@ For non-interactive use, `--no-input` skips GitHub setup unless you add
 `--github private` or `--github public`. Public automation enables Pages;
 private automation leaves it and docs deployment disabled. A requested setup
 failure exits nonzero while preserving the generated project directory.
+
+For a confirmed HTTPS setup, the generator configures Git to use the GitHub CLI
+credential helper for `github.com`, so an authenticated `gh` session can also
+complete the first push. SSH setup does not change Git credential helpers.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -40,5 +40,13 @@ repository, initializes Git, pushes `main`, enables Pages, or creates the
 `pypi` environment. Existing nonempty repositories are never modified
 automatically.
 
+Pages is a separate decision. It defaults to on for public repositories. For
+private or internal repositories, it defaults to off and warns that the
+published site can still be public and that the feature may require a paid
+GitHub plan. The generator displays the actual visibility before asking to
+connect to an existing empty repository.
+
 For non-interactive use, `--no-input` skips GitHub setup unless you add
-`--github private` or `--github public`.
+`--github private` or `--github public`. Public automation enables Pages;
+private automation leaves it disabled. A requested setup failure exits nonzero
+while preserving the generated project directory.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -37,16 +37,18 @@ without a Git commit or remote repository.
 If you opt in, visibility defaults to private. The generator shows the full
 plan and asks for final confirmation before it creates or connects to an empty
 repository, initializes Git, pushes `main`, enables Pages, or creates the
-`pypi` environment. Existing nonempty repositories are never modified
+`pypi` environment. The plan also shows whether the docs deployment workflow
+will be enabled or paused. Existing nonempty repositories are never modified
 automatically.
 
 Pages is a separate decision. It defaults to on for public repositories. For
 private or internal repositories, it defaults to off and warns that the
 published site can still be public and that the feature may require a paid
 GitHub plan. The generator displays the actual visibility before asking to
-connect to an existing empty repository.
+connect to an existing empty repository. The docs deployment workflow follows
+the confirmed Pages choice, avoiding a failed deployment when Pages is off.
 
 For non-interactive use, `--no-input` skips GitHub setup unless you add
 `--github private` or `--github public`. Public automation enables Pages;
-private automation leaves it disabled. A requested setup failure exits nonzero
-while preserving the generated project directory.
+private automation leaves it and docs deployment disabled. A requested setup
+failure exits nonzero while preserving the generated project directory.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -27,3 +27,18 @@ The package name is auto-generated from the project name by replacing spaces wit
 - **pypi_username**: Your PyPI account username. Used only for a link to your PyPI profile in the README.
 - **author_website**: Your personal website URL (optional). When provided, the "Created by" link in the README points here. When left blank, it defaults to your GitHub profile URL.
 - **first_version**: The starting version number of the package. Defaults to `0.1.0`.
+
+## GitHub setup
+
+After the template prompts, the generator separately asks whether to set up a
+GitHub repository. Pressing Enter selects no and leaves the generated project
+without a Git commit or remote repository.
+
+If you opt in, visibility defaults to private. The generator shows the full
+plan and asks for final confirmation before it creates or connects to an empty
+repository, initializes Git, pushes `main`, enables Pages, or creates the
+`pypi` environment. Existing nonempty repositories are never modified
+automatically.
+
+For non-interactive use, `--no-input` skips GitHub setup unless you add
+`--github private` or `--github public`.

--- a/docs/pypi_release_checklist.md
+++ b/docs/pypi_release_checklist.md
@@ -13,7 +13,10 @@
    - **Workflow name:** `publish.yml`
    - **Environment name:** `pypi`
 
-4. The post-generation hook already created the `pypi` environment. If it didn't, go to Settings > Environments > New environment and name it `pypi`. Optionally add required reviewers and restrict deployment to `v*` tags.
+4. If you opted into successful GitHub setup, the post-generation hook created
+   the `pypi` environment. Otherwise, go to Settings > Environments > New
+   environment and name it `pypi`. Optionally add required reviewers and
+   restrict deployment to `v*` tags.
 
 5. Run `just release` to trigger the publish (see below).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,16 @@
 
 ## Docs site shows 404
 
-Make sure GitHub Pages is configured to deploy from **GitHub Actions** (not a branch). Go to your repo's Settings > Pages and set the source to **GitHub Actions**. If the docs workflow already ran before you enabled Pages, go to Actions, find the "Documentation" workflow, and click "Re-run all jobs."
+Make sure GitHub Pages is configured to deploy from **GitHub Actions** (not a
+branch). Go to your repo's Settings > Pages and set the source to **GitHub
+Actions**. Then enable the generated deployment workflow:
+
+```bash
+gh variable set DOCS_DEPLOYMENT_ENABLED --repo OWNER/REPOSITORY --body true
+```
+
+Push to `main` or go to Actions, find the "Documentation" workflow, and run it
+manually.
 
 ## Tag push didn't publish to PyPI
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,7 +15,9 @@ Make sure GitHub Pages is configured to deploy from **GitHub Actions** (not a br
 The most common causes:
 
 - **Trusted Publisher not configured.** You need to register your repo as a trusted publisher on PyPI before the first release. See the [PyPI Release Checklist](pypi_release_checklist.md).
-- **`pypi` environment not created.** The post-generation hook creates this automatically. If it didn't, go to Settings > Environments and create an environment named `pypi`.
+- **`pypi` environment not created.** The post-generation hook attempts this
+  only when you opt into GitHub setup. Go to Settings > Environments and create
+  an environment named `pypi`.
 - **Tag format wrong.** Tags must match `v*` (e.g., `v0.1.0`). The `just tag` command handles this for you.
 
 If you got the Trusted Publisher configuration wrong, you can delete it on PyPI and create it again.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -47,6 +47,7 @@ GitHub setup plan:
   - create https://github.com/your-username/my-package as a public repository
   - initialize Git and create the first commit
   - enable GitHub Pages (publishes a website)
+  - enable the documentation deployment workflow
   - create the pypi environment
   - push main over SSH
 
@@ -54,6 +55,7 @@ Continue? [y/N]: y
 Git initialized with first commit
 GitHub repository created: https://github.com/your-username/my-package
 GitHub Pages enabled for your-username/my-package
+Documentation deployment workflow enabled for your-username/my-package
 GitHub environment 'pypi' created for your-username/my-package
 Pushed to https://github.com/your-username/my-package
 
@@ -79,7 +81,9 @@ the partial setup.
 For a private repository, Pages defaults to off. GitHub Pages can publish a
 public website even when its repository is private, and Pages for a private
 repository may require a paid plan. The interactive flow explains this and
-requires a separate opt-in before enabling Pages.
+requires a separate opt-in before enabling Pages. If you leave Pages off, the
+documentation deployment workflow stays paused rather than failing on the
+first push; local docs preview and builds still work.
 
 For non-interactive automation, make the opt-in explicit:
 
@@ -89,7 +93,8 @@ uvx cookiecutter-pypackage --no-input --github private \
     package_name=my-package
 ```
 
-Use `--github public` when automation should also enable Pages.
+Use `--github public` when automation should also enable Pages and
+documentation deployment.
 
 ## Step 2: Look around
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -8,7 +8,7 @@ By the end of this tutorial, you'll have a Python package with a working CLI, a 
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - [just](https://github.com/casey/just#installation) (task runner)
 - [git](https://git-scm.com/)
-- [gh](https://cli.github.com/) (GitHub CLI, for automatic repo and Pages setup)
+- [gh](https://cli.github.com/) (GitHub CLI, if you want automatic repo setup)
 - A [GitHub account](https://github.com/)
 - A [PyPI account](https://pypi.org/) (when you're ready to publish)
 
@@ -34,14 +34,26 @@ You'll be prompted for some values. See [Prompts](prompts.md) for details on eac
 [11/11] first_version (0.1.0):
 ```
 
-The hook will ask whether to make the GitHub repo public or private, then set everything up:
+GitHub setup is optional and defaults to no. If you opt in, repository
+visibility defaults to private and the generator shows every action before
+making changes:
 
 ```
-Make the GitHub repo public or private? [public/private] (public): public
-GitHub repo created: https://github.com/your-username/my-package
-GitHub Pages enabled for your-username/my-package (source: GitHub Actions)
+Set up a GitHub repository now? [y/N]: y
+Repository visibility [private/public] (private):
+
+GitHub setup plan:
+  - create https://github.com/your-username/my-package as a private repository
+  - initialize Git and create the first commit
+  - enable GitHub Pages
+  - create the pypi environment
+  - push main
+
+Continue? [y/N]: y
+Git initialized with first commit
+GitHub repository created: https://github.com/your-username/my-package
+GitHub Pages enabled for your-username/my-package
 GitHub environment 'pypi' created for your-username/my-package
-Git initialized with initial commit
 Pushed to https://github.com/your-username/my-package
 
 To publish to PyPI, add a pending publisher at:
@@ -53,7 +65,17 @@ Your Python package project has been created successfully!
 
 CI runs automatically on push. Check the Actions tab and you should see it pass: linting, type checking, and tests across three Python versions. Your docs site will be live at `https://your-username.github.io/my-package/` within a couple of minutes.
 
-If you don't have the `gh` CLI, the hook skips repo creation and prints manual instructions instead.
+Pressing Enter at the first GitHub question generates the project locally
+without creating a repository or Git commit. The same safe default applies when
+`gh` is unavailable or unauthenticated.
+
+For non-interactive automation, make the opt-in explicit:
+
+```bash
+uvx cookiecutter-pypackage --no-input --github private \
+    project_name="My Package" \
+    package_name=my-package
+```
 
 ## Step 2: Look around
 
@@ -128,7 +150,8 @@ Run `just qa` to verify everything still passes. Push your changes and watch CI 
 
 ## Step 6: Set up PyPI publishing
 
-The post-generation hook printed the URL and form values you need:
+If you opted into GitHub setup, the post-generation hook printed the URL and
+form values you need:
 
 ```
 To publish to PyPI, add a pending publisher at:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -40,12 +40,13 @@ making changes:
 
 ```
 Set up a GitHub repository now? [y/N]: y
-Repository visibility [private/public] (private):
+Repository visibility [private/public] (private): public
+Enable GitHub Pages? [Y/n]:
 
 GitHub setup plan:
-  - create https://github.com/your-username/my-package as a private repository
+  - create https://github.com/your-username/my-package as a public repository
   - initialize Git and create the first commit
-  - enable GitHub Pages
+  - enable GitHub Pages (publishes a website)
   - create the pypi environment
   - push main
 
@@ -66,8 +67,15 @@ Your Python package project has been created successfully!
 CI runs automatically on push. Check the Actions tab and you should see it pass: linting, type checking, and tests across three Python versions. Your docs site will be live at `https://your-username.github.io/my-package/` within a couple of minutes.
 
 Pressing Enter at the first GitHub question generates the project locally
-without creating a repository or Git commit. The same safe default applies when
-`gh` is unavailable or unauthenticated.
+without creating a repository or Git commit. If you opt in but `gh` is
+unavailable, unauthenticated, or another requested action fails, the command
+exits nonzero and keeps the generated directory so you can inspect or recover
+the partial setup.
+
+For a private repository, Pages defaults to off. GitHub Pages can publish a
+public website even when its repository is private, and Pages for a private
+repository may require a paid plan. The interactive flow explains this and
+requires a separate opt-in before enabling Pages.
 
 For non-interactive automation, make the opt-in explicit:
 
@@ -76,6 +84,8 @@ uvx cookiecutter-pypackage --no-input --github private \
     project_name="My Package" \
     package_name=my-package
 ```
+
+Use `--github public` when automation should also enable Pages.
 
 ## Step 2: Look around
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -48,7 +48,7 @@ GitHub setup plan:
   - initialize Git and create the first commit
   - enable GitHub Pages (publishes a website)
   - create the pypi environment
-  - push main
+  - push main over SSH
 
 Continue? [y/N]: y
 Git initialized with first commit
@@ -64,7 +64,11 @@ https://pypi.org/manage/account/publishing/
 Your Python package project has been created successfully!
 ```
 
-CI runs automatically on push. Check the Actions tab and you should see it pass: linting, type checking, and tests across three Python versions. Your docs site will be live at `https://your-username.github.io/my-package/` within a couple of minutes.
+The transport in the plan follows `gh`'s `git_protocol` setting, so it may say
+SSH or HTTPS. CI runs automatically on push. Check the Actions tab and you
+should see it pass: linting, type checking, and tests across three Python
+versions. Your docs site will be live at
+`https://your-username.github.io/my-package/` within a couple of minutes.
 
 Pressing Enter at the first GitHub question generates the project locally
 without creating a repository or Git commit. If you opt in but `gh` is

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -89,6 +89,10 @@ For non-interactive automation, make the opt-in explicit:
 
 ```bash
 uvx cookiecutter-pypackage --no-input --github private \
+    full_name="Your Name" \
+    email="you@example.com" \
+    github_username=yourhandle \
+    author_website="" \
     project_name="My Package" \
     package_name=my-package
 ```

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -261,6 +261,8 @@ def print_github_plan(plan):
         )
     else:
         print(f"  - create {github_repository_url()} as a {plan.visibility} repository")
+    if plan.git_protocol == "https":
+        print("  - configure Git to use GitHub CLI credentials for HTTPS")
     print("  - initialize Git and create the first commit")
     if plan.enable_pages:
         print("  - enable GitHub Pages (publishes a website)")
@@ -431,6 +433,21 @@ def initialize_git():
     return True
 
 
+def configure_git_credentials(protocol):
+    """Configure Git to use the authenticated GitHub CLI for HTTPS pushes."""
+    if protocol != "https":
+        return True
+
+    result = run_command("gh", "auth", "setup-git", "--hostname", GITHUB_HOST)
+    if result.returncode == 0:
+        print(f"  Git configured to use GitHub CLI credentials for {GITHUB_HOST}")
+        return True
+
+    print(f"  Could not configure Git credentials for HTTPS: {command_error(result)}")
+    print(f"  Run `gh auth setup-git --hostname {GITHUB_HOST}`, then generate again.")
+    return False
+
+
 def add_remote_and_push(protocol):
     """Connect the confirmed GitHub repository and push its first commit."""
     remote_url = github_remote_url(protocol)
@@ -574,6 +591,9 @@ def main():
 
     if plan is None:
         print("  Project generated locally without creating a Git commit.")
+    elif not configure_git_credentials(plan.git_protocol):
+        print("  Project generated, but Git credential setup did not complete.")
+        failed = True
     elif not initialize_git():
         print("  Project generated, but Git setup did not complete.")
         failed = True

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,147 +1,230 @@
 #!/usr/bin/env python
 """Post-generation hooks for cookiecutter-pypackage."""
 
+import json
 import os
 import shutil
 import subprocess
+from typing import NamedTuple
 
 OWNER = "{{ cookiecutter.github_repo_owner }}"
 REPO = "{{ cookiecutter.package_name }}"
+DESCRIPTION = "{{ cookiecutter.project_short_description | replace('\"', '\\\"') }}"
+
+GITHUB_SETUP_ENV = "COOKIECUTTER_PYPACKAGE_GITHUB"
+GITHUB_SETUP_MODES = {"ask", "skip", "private", "public"}
 
 
-def create_github_repo():
-    """Create the GitHub repo so subsequent setup steps can configure it.
+class GitHubSetupPlan(NamedTuple):
+    """A confirmed plan for creating or connecting to a GitHub repository."""
 
-    Asks the user whether the repo should be public or private.
-    Uses gh repo create which handles both personal and org repos.
-    """
-    if not shutil.which("gh"):
-        print("  gh CLI not found, skipping repo creation.")
-        print(f"  Create manually: https://github.com/new?name={REPO}&owner={OWNER}")
-        return False
+    existing: bool
+    visibility: str | None
 
-    if not os.isatty(0):
-        return False
 
-    choice = (
-        input("  Make the GitHub repo public or private? [public/private] (public): ")
-        .strip()
-        .lower()
-    )
-    visibility = "--private" if choice == "private" else "--public"
-
+def run_command(*command):
+    """Run a command without raising so the hook can report useful failures."""
     try:
-        result = subprocess.run(
-            [
-                "gh",
-                "repo",
-                "create",
-                f"{OWNER}/{REPO}",
-                visibility,
-                "--description",
-                "{{ cookiecutter.project_short_description | replace('\"', '\\\"') }}",
-            ],
+        return subprocess.run(
+            list(command),
             capture_output=True,
             text=True,
             check=False,
         )
-        if result.returncode == 0:
-            print(f"  GitHub repo created: https://github.com/{OWNER}/{REPO}")
+    except OSError as error:
+        return subprocess.CompletedProcess(
+            args=list(command),
+            returncode=1,
+            stdout="",
+            stderr=str(error),
+        )
+
+
+def command_error(result):
+    """Return the most useful captured error text for a failed command."""
+    return (result.stderr or result.stdout).strip() or "unknown error"
+
+
+def prompt_yes_no(message, *, default=False):
+    """Prompt until the user enters an unambiguous yes or no."""
+    suffix = "[Y/n]" if default else "[y/N]"
+    while True:
+        answer = input(f"{message} {suffix}: ").strip().lower()
+        if not answer:
+            return default
+        if answer in {"y", "yes"}:
             return True
-        elif "already exists" in result.stderr:
-            print(f"  GitHub repo {OWNER}/{REPO} already exists")
-            return True
-        else:
-            print(f"  Could not create repo: {result.stderr.strip()}")
-            print(
-                f"  Create manually: https://github.com/new?name={REPO}&owner={OWNER}"
-            )
+        if answer in {"n", "no"}:
             return False
-    except Exception:
-        print("  Could not create repo automatically.")
-        print(f"  Create manually: https://github.com/new?name={REPO}&owner={OWNER}")
+        print("  Please answer yes or no.")
+
+
+def prompt_visibility():
+    """Ask for repository visibility, defaulting safely to private."""
+    while True:
+        answer = input("Repository visibility [private/public] (private): ")
+        visibility = answer.strip().lower()
+        if not visibility:
+            return "private"
+        if visibility in {"private", "public"}:
+            return visibility
+        print("  Please enter private or public.")
+
+
+def github_setup_mode():
+    """Read and validate the setup mode supplied by the package CLI."""
+    mode = os.environ.get(GITHUB_SETUP_ENV, "ask").strip().lower()
+    if mode not in GITHUB_SETUP_MODES:
+        print(
+            f"  Ignoring invalid {GITHUB_SETUP_ENV} value {mode!r}; "
+            "GitHub setup will be skipped."
+        )
+        return "skip"
+    return mode
+
+
+def github_cli_ready():
+    """Check that GitHub CLI is installed and authenticated."""
+    if not shutil.which("gh"):
+        print("  GitHub CLI not found; GitHub setup will be skipped.")
+        print("  Install it from https://cli.github.com/ and run `gh auth login`.")
         return False
 
+    result = run_command("gh", "auth", "status")
+    if result.returncode == 0:
+        return True
 
-def enable_github_pages():
-    """Enable GitHub Pages with Actions source if gh CLI is available.
+    print("  GitHub CLI is not authenticated; GitHub setup will be skipped.")
+    print("  Run `gh auth login`, then generate the project again.")
+    return False
 
-    The docs workflow deploys to GitHub Pages via actions/deploy-pages,
-    which requires Pages to be configured with build_type=workflow.
-    """
-    if not shutil.which("gh"):
-        print("  gh CLI not found, skipping GitHub Pages setup.")
-        print("  Enable manually: Settings > Pages > Source > GitHub Actions")
-        return
+
+def github_repository_state():
+    """Return missing, empty, nonempty, or error for the target repository."""
+    result = run_command(
+        "gh",
+        "repo",
+        "view",
+        f"{OWNER}/{REPO}",
+        "--json",
+        "isEmpty",
+    )
+    if result.returncode != 0:
+        error = command_error(result)
+        missing_markers = (
+            "Could not resolve to a Repository",
+            "HTTP 404",
+            "Not Found",
+        )
+        if any(marker in error for marker in missing_markers):
+            return "missing"
+        print(f"  Could not check GitHub repository {OWNER}/{REPO}: {error}")
+        return "error"
 
     try:
-        subprocess.run(
-            [
-                "gh",
-                "api",
-                f"repos/{OWNER}/{REPO}/pages",
-                "-X",
-                "POST",
-                "-f",
-                "build_type=workflow",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
+        is_empty = json.loads(result.stdout)["isEmpty"]
+    except (KeyError, TypeError, json.JSONDecodeError):
+        print(f"  GitHub returned an unexpected response for {OWNER}/{REPO}.")
+        return "error"
+
+    return "empty" if is_empty else "nonempty"
+
+
+def print_github_plan(plan):
+    """Show every external and local action before confirmation."""
+    print()
+    print("GitHub setup plan:")
+    if plan.existing:
+        print(f"  - connect to the empty repository https://github.com/{OWNER}/{REPO}")
+    else:
+        print(
+            f"  - create https://github.com/{OWNER}/{REPO} "
+            f"as a {plan.visibility} repository"
         )
-        # If already enabled with a different source, switch it
-        subprocess.run(
-            [
-                "gh",
-                "api",
-                f"repos/{OWNER}/{REPO}/pages",
-                "-X",
-                "PUT",
-                "-f",
-                "build_type=workflow",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        print(f"  GitHub Pages enabled for {OWNER}/{REPO} (source: GitHub Actions)")
-    except Exception:
-        print("  Could not configure GitHub Pages automatically.")
-        print("  Enable manually: Settings > Pages > Source > GitHub Actions")
+    print("  - initialize Git and create the first commit")
+    print("  - enable GitHub Pages")
+    print("  - create the pypi environment")
+    print("  - push main")
+    print()
 
 
-def create_pypi_environment():
-    """Create a 'pypi' GitHub environment for trusted publishing.
+def choose_github_setup():
+    """Collect explicit consent and return a safe GitHub setup plan."""
+    mode = github_setup_mode()
+    if mode == "skip":
+        print("  GitHub setup skipped.")
+        return None
 
-    The publish workflow uses an environment named 'pypi' for OIDC-based
-    trusted publishing to PyPI. This creates the environment via the API.
-    """
-    if not shutil.which("gh"):
-        print("  gh CLI not found, skipping pypi environment setup.")
-        print("  Create manually: Settings > Environments > New environment > pypi")
-        return
+    interactive = mode == "ask"
+    if interactive:
+        if not os.isatty(0):
+            print("  Non-interactive run: GitHub setup skipped.")
+            print(
+                "  Use `--github private` or `--github public` "
+                "to opt in during automation."
+            )
+            return None
+        if not prompt_yes_no("Set up a GitHub repository now?"):
+            print("  GitHub setup skipped.")
+            return None
 
-    try:
-        result = subprocess.run(
-            [
-                "gh",
-                "api",
-                f"repos/{OWNER}/{REPO}/environments/pypi",
-                "-X",
-                "PUT",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            print(f"  GitHub environment 'pypi' created for {OWNER}/{REPO}")
-        else:
-            print("  Could not create pypi environment automatically.")
-            print("  Create manually: Settings > Environments > New environment > pypi")
-    except Exception:
-        print("  Could not create pypi environment automatically.")
-        print("  Create manually: Settings > Environments > New environment > pypi")
+    if not github_cli_ready():
+        return None
+
+    repository_state = github_repository_state()
+    if repository_state == "error":
+        return None
+    if repository_state == "nonempty":
+        print(f"  GitHub repository {OWNER}/{REPO} already exists and is not empty.")
+        print("  For safety, the generator will not modify it automatically.")
+        return None
+
+    if repository_state == "empty":
+        if not interactive:
+            print(f"  GitHub repository {OWNER}/{REPO} already exists and is empty.")
+            print(
+                "  Run interactively to confirm connecting to an existing repository."
+            )
+            return None
+        if not prompt_yes_no(
+            f"GitHub repository {OWNER}/{REPO} is empty. Connect to it?"
+        ):
+            print("  Existing GitHub repository left unchanged.")
+            return None
+        plan = GitHubSetupPlan(existing=True, visibility=None)
+    else:
+        visibility = prompt_visibility() if interactive else mode
+        plan = GitHubSetupPlan(existing=False, visibility=visibility)
+
+    print_github_plan(plan)
+    if interactive and not prompt_yes_no("Continue?"):
+        print("  GitHub setup cancelled. No repository or Git commit was created.")
+        return None
+    return plan
+
+
+def prepare_github_repository(plan):
+    """Create the confirmed GitHub repository or select an empty one."""
+    if plan.existing:
+        print(f"  Using existing empty repository: https://github.com/{OWNER}/{REPO}")
+        return True
+
+    result = run_command(
+        "gh",
+        "repo",
+        "create",
+        f"{OWNER}/{REPO}",
+        f"--{plan.visibility}",
+        "--description",
+        DESCRIPTION,
+    )
+    if result.returncode == 0:
+        print(f"  GitHub repository created: https://github.com/{OWNER}/{REPO}")
+        return True
+
+    print(f"  Could not create GitHub repository: {command_error(result)}")
+    print("  The generated project remains in its local Git repository.")
+    return False
 
 
 IMPORT_NAME = "{{ cookiecutter.import_name }}"
@@ -168,73 +251,154 @@ https://github.com/audreyfeldroy/cookiecutter-pypackage scaffolding
 """
 
 
-def git_init_and_push(repo_created):
-    """Initialize git, make the initial commit, and push if repo exists."""
-    try:
-        subprocess.run(["git", "init", "-b", "main"], capture_output=True, check=True)
-        subprocess.run(["git", "add", "."], capture_output=True, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", COMMIT_MESSAGE],
-            capture_output=True,
-            check=True,
-        )
-        print("  Git initialized with initial commit")
-    except Exception:
-        print("  Could not initialize git repo.")
-        return
+def initialize_git():
+    """Initialize Git and make the confirmed first commit locally."""
+    steps = (
+        (
+            ("git", "init", "-b", "main"),
+            "initialize the local Git repository",
+        ),
+        (("git", "add", "."), "stage the generated project"),
+        (
+            ("git", "commit", "-m", COMMIT_MESSAGE),
+            "create the first Git commit",
+        ),
+    )
 
-    if repo_created:
-        try:
-            subprocess.run(
-                [
-                    "git",
-                    "remote",
-                    "add",
-                    "origin",
-                    f"https://github.com/{OWNER}/{REPO}.git",
-                ],
-                capture_output=True,
-                check=True,
-            )
-            subprocess.run(
-                ["git", "push", "-u", "origin", "main"],
-                capture_output=True,
-                check=True,
-            )
-            print(f"  Pushed to https://github.com/{OWNER}/{REPO}")
-        except Exception:
+    for command, description in steps:
+        result = run_command(*command)
+        if result.returncode != 0:
+            print(f"  Could not {description}: {command_error(result)}")
+            print("  GitHub setup stopped before creating or modifying a repository.")
+            return False
+
+    print("  Git initialized with first commit")
+    return True
+
+
+def add_remote_and_push():
+    """Connect the confirmed GitHub repository and push its first commit."""
+    steps = (
+        (
+            (
+                "git",
+                "remote",
+                "add",
+                "origin",
+                f"https://github.com/{OWNER}/{REPO}.git",
+            ),
+            "add the GitHub remote",
+        ),
+        (
+            ("git", "push", "-u", "origin", "main"),
+            "push main to GitHub",
+        ),
+    )
+
+    for command, description in steps:
+        result = run_command(*command)
+        if result.returncode != 0:
+            print(f"  Could not {description}: {command_error(result)}")
             print(
-                f"  Could not push. Run: git remote add origin https://github.com/{OWNER}/{REPO}.git && git push -u origin main"
+                "  The repository may need manual setup before the first push succeeds."
             )
+            return False
+
+    print(f"  Pushed to https://github.com/{OWNER}/{REPO}")
+    return True
+
+
+def enable_github_pages():
+    """Enable GitHub Pages with Actions as the deployment source."""
+    create_result = run_command(
+        "gh",
+        "api",
+        f"repos/{OWNER}/{REPO}/pages",
+        "-X",
+        "POST",
+        "-f",
+        "build_type=workflow",
+    )
+    if create_result.returncode == 0:
+        print(f"  GitHub Pages enabled for {OWNER}/{REPO}")
+        return True
+
+    update_result = run_command(
+        "gh",
+        "api",
+        f"repos/{OWNER}/{REPO}/pages",
+        "-X",
+        "PUT",
+        "-f",
+        "build_type=workflow",
+    )
+    if update_result.returncode == 0:
+        print(f"  GitHub Pages configured for {OWNER}/{REPO}")
+        return True
+
+    print(
+        "  Could not configure GitHub Pages: "
+        f"{command_error(update_result) or command_error(create_result)}"
+    )
+    print("  Configure it manually: Settings > Pages > Source > GitHub Actions")
+    return False
+
+
+def create_pypi_environment():
+    """Create the GitHub environment used for PyPI trusted publishing."""
+    result = run_command(
+        "gh",
+        "api",
+        f"repos/{OWNER}/{REPO}/environments/pypi",
+        "-X",
+        "PUT",
+    )
+    if result.returncode == 0:
+        print(f"  GitHub environment 'pypi' created for {OWNER}/{REPO}")
+        return True
+
+    print(f"  Could not create the pypi environment: {command_error(result)}")
+    print("  Create it manually: Settings > Environments > New environment > pypi")
+    return False
 
 
 def print_pypi_trusted_publisher_instructions():
-    """Print instructions for adding a PyPI trusted publisher.
+    """Print the exact values needed to add a pending publisher on PyPI."""
+    print()
+    print("To publish to PyPI, add a pending publisher at:")
+    print("https://pypi.org/manage/account/publishing/")
+    print()
+    print("Fill in these values:")
+    print(f"  PyPI project name:  {REPO}")
+    print(f"  Owner:              {OWNER}")
+    print(f"  Repository:         {REPO}")
+    print("  Workflow:           publish.yml")
+    print("  Environment:        pypi")
+    print()
+    print("Then release with:")
+    print("  just release")
+    print()
 
-    PyPI has no API for this, it must be done through the web UI.
-    Print the exact URL and values so the user can set it up quickly.
-    """
-    print()
-    print("  To publish to PyPI, add a pending publisher at:")
-    print("  https://pypi.org/manage/account/publishing/")
-    print()
-    print("  Fill in these values:")
-    print(f"    PyPI project name:  {REPO}")
-    print(f"    Owner:              {OWNER}")
-    print(f"    Repository:         {REPO}")
-    print("    Workflow:           publish.yml")
-    print("    Environment:        pypi")
-    print()
-    print("  Then release with:")
-    print("    just release")
-    print()
+
+def main():
+    """Run the confirmed setup flow after Cookiecutter renders the project."""
+    plan = choose_github_setup()
+    if plan is None:
+        print("  Project generated locally without creating a Git commit.")
+    elif not initialize_git():
+        print("  Project generated, but Git setup did not complete.")
+    elif not prepare_github_repository(plan):
+        print("  Project generated with a local commit, but no GitHub repository.")
+    else:
+        enable_github_pages()
+        create_pypi_environment()
+        if add_remote_and_push():
+            print_pypi_trusted_publisher_instructions()
+        else:
+            print("  Project generated, but the first GitHub push did not complete.")
+
+    print("Your Python package project has been created successfully!")
 
 
 if __name__ == "__main__":
-    repo_created = create_github_repo()
-    if repo_created:
-        enable_github_pages()
-        create_pypi_environment()
-    git_init_and_push(repo_created)
-    print_pypi_trusted_publisher_instructions()
-    print("Your Python package project has been created successfully!")
+    main()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -399,7 +399,10 @@ def initialize_git():
         result = run_command(*command)
         if result.returncode != 0:
             print(f"  Could not {description}: {command_error(result)}")
-            print("  GitHub setup stopped before creating or modifying a repository.")
+            print(
+                "  GitHub setup stopped before creating or modifying "
+                "a GitHub repository."
+            )
             return False
 
     print("  Git initialized with first commit")

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -25,6 +25,7 @@ DESCRIPTION = json.loads(
 
 GITHUB_SETUP_ENV = "COOKIECUTTER_PYPACKAGE_GITHUB"
 GITHUB_SETUP_MODES = {"ask", "skip", "private", "public"}
+DOCS_DEPLOYMENT_VARIABLE = "DOCS_DEPLOYMENT_ENABLED"
 
 
 class GitHubSetupPlan(NamedTuple):
@@ -241,8 +242,10 @@ def print_github_plan(plan):
     print("  - initialize Git and create the first commit")
     if plan.enable_pages:
         print("  - enable GitHub Pages (publishes a website)")
+        print("  - enable the documentation deployment workflow")
     else:
         print("  - leave GitHub Pages disabled")
+        print("  - keep the documentation deployment workflow paused")
     print("  - create the pypi environment")
     print(f"  - push main over {plan.git_protocol.upper()}")
     print()
@@ -472,6 +475,35 @@ def enable_github_pages():
     return False
 
 
+def configure_docs_deployment(enabled):
+    """Record whether the GitHub Pages deployment workflow should run."""
+    value = "true" if enabled else "false"
+    result = run_command(
+        "gh",
+        "variable",
+        "set",
+        DOCS_DEPLOYMENT_VARIABLE,
+        "--repo",
+        f"{OWNER}/{REPO}",
+        "--body",
+        value,
+    )
+    if result.returncode == 0:
+        status = "enabled" if enabled else "paused"
+        print(f"  Documentation deployment workflow {status} for {OWNER}/{REPO}")
+        return True
+
+    print(
+        "  Could not configure the documentation deployment workflow: "
+        f"{command_error(result)}"
+    )
+    print(
+        f"  Set it manually: gh variable set {DOCS_DEPLOYMENT_VARIABLE} "
+        f"--repo {OWNER}/{REPO} --body {value}"
+    )
+    return False
+
+
 def create_pypi_environment():
     """Create the GitHub environment used for PyPI trusted publishing."""
     result = run_command(
@@ -530,13 +562,21 @@ def main():
         else:
             print("  GitHub Pages setup skipped.")
 
+        docs_deployment_ready = configure_docs_deployment(
+            plan.enable_pages and pages_ready
+        )
         environment_ready = create_pypi_environment()
         push_succeeded = add_remote_and_push(plan.git_protocol)
         if push_succeeded:
             print_pypi_trusted_publisher_instructions()
         else:
             print("  Project generated, but the first GitHub push did not complete.")
-        failed = not (pages_ready and environment_ready and push_succeeded)
+        failed = not (
+            pages_ready
+            and docs_deployment_ready
+            and environment_ready
+            and push_succeeded
+        )
 
     if failed:
         print("Project files were generated, but GitHub setup did not complete.")

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -33,6 +33,7 @@ class GitHubSetupPlan(NamedTuple):
     existing: bool
     visibility: str
     enable_pages: bool
+    git_protocol: str
 
 
 class GitHubSetupDecision(NamedTuple):
@@ -173,6 +174,36 @@ def github_repository_state():
     return GitHubRepositoryState(status, visibility)
 
 
+def github_git_protocol():
+    """Return the authenticated GitHub CLI's configured Git transport."""
+    result = run_command(
+        "gh",
+        "config",
+        "get",
+        "git_protocol",
+        "--host",
+        "github.com",
+    )
+    if result.returncode != 0:
+        print(f"  Could not read GitHub's Git protocol: {command_error(result)}")
+        return None
+
+    protocol = result.stdout.strip().lower()
+    if protocol in {"https", "ssh"}:
+        return protocol
+
+    print(f"  GitHub CLI returned an unsupported Git protocol: {protocol or 'empty'}.")
+    print("  Set it with `gh config set git_protocol ssh --host github.com`.")
+    return None
+
+
+def github_remote_url(protocol):
+    """Build a GitHub remote URL using the user's configured transport."""
+    if protocol == "ssh":
+        return f"git@github.com:{OWNER}/{REPO}.git"
+    return f"https://github.com/{OWNER}/{REPO}.git"
+
+
 def choose_pages_setup(visibility, *, interactive):
     """Choose whether to publish documentation through GitHub Pages."""
     if visibility == "public":
@@ -213,7 +244,7 @@ def print_github_plan(plan):
     else:
         print("  - leave GitHub Pages disabled")
     print("  - create the pypi environment")
-    print("  - push main")
+    print(f"  - push main over {plan.git_protocol.upper()}")
     print()
 
 
@@ -247,6 +278,10 @@ def choose_github_setup(mode):
         print("  For safety, the generator will not modify it automatically.")
         return GitHubSetupDecision(None, failed=True)
 
+    git_protocol = github_git_protocol()
+    if git_protocol is None:
+        return GitHubSetupDecision(None, failed=True)
+
     if repository_state.status == "empty":
         if not interactive:
             print(
@@ -277,6 +312,7 @@ def choose_github_setup(mode):
         existing=existing,
         visibility=visibility,
         enable_pages=enable_pages,
+        git_protocol=git_protocol,
     )
 
     print_github_plan(plan)
@@ -367,8 +403,9 @@ def initialize_git():
     return True
 
 
-def add_remote_and_push():
+def add_remote_and_push(protocol):
     """Connect the confirmed GitHub repository and push its first commit."""
+    remote_url = github_remote_url(protocol)
     steps = (
         (
             (
@@ -376,7 +413,7 @@ def add_remote_and_push():
                 "remote",
                 "add",
                 "origin",
-                f"https://github.com/{OWNER}/{REPO}.git",
+                remote_url,
             ),
             "add the GitHub remote",
         ),
@@ -494,7 +531,7 @@ def main():
             print("  GitHub Pages setup skipped.")
 
         environment_ready = create_pypi_environment()
-        push_succeeded = add_remote_and_push()
+        push_succeeded = add_remote_and_push(plan.git_protocol)
         if push_succeeded:
             print_pypi_trusted_publisher_instructions()
         else:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,7 +9,11 @@ from typing import NamedTuple
 
 OWNER = "{{ cookiecutter.github_repo_owner }}"
 REPO = "{{ cookiecutter.package_name }}"
-DESCRIPTION = "{{ cookiecutter.project_short_description | replace('\"', '\\\"') }}"
+DESCRIPTION = json.loads(
+    r"""
+{{ cookiecutter.project_short_description | tojson }}
+""".strip()
+)
 
 GITHUB_SETUP_ENV = "COOKIECUTTER_PYPACKAGE_GITHUB"
 GITHUB_SETUP_MODES = {"ask", "skip", "private", "public"}
@@ -19,7 +23,22 @@ class GitHubSetupPlan(NamedTuple):
     """A confirmed plan for creating or connecting to a GitHub repository."""
 
     existing: bool
-    visibility: str | None
+    visibility: str
+    enable_pages: bool
+
+
+class GitHubSetupDecision(NamedTuple):
+    """The result of collecting consent and checking GitHub state."""
+
+    plan: GitHubSetupPlan | None
+    failed: bool = False
+
+
+class GitHubRepositoryState(NamedTuple):
+    """The existence, contents, and visibility of the target repository."""
+
+    status: str
+    visibility: str | None = None
 
 
 def run_command(*command):
@@ -100,14 +119,14 @@ def github_cli_ready():
 
 
 def github_repository_state():
-    """Return missing, empty, nonempty, or error for the target repository."""
+    """Return the target repository's contents and visibility."""
     result = run_command(
         "gh",
         "repo",
         "view",
         f"{OWNER}/{REPO}",
         "--json",
-        "isEmpty",
+        "isEmpty,visibility",
     )
     if result.returncode != 0:
         error = command_error(result)
@@ -117,17 +136,53 @@ def github_repository_state():
             "Not Found",
         )
         if any(marker in error for marker in missing_markers):
-            return "missing"
+            return GitHubRepositoryState("missing")
         print(f"  Could not check GitHub repository {OWNER}/{REPO}: {error}")
-        return "error"
+        return GitHubRepositoryState("error")
 
     try:
-        is_empty = json.loads(result.stdout)["isEmpty"]
+        data = json.loads(result.stdout)
+        is_empty = data["isEmpty"]
+        raw_visibility = data["visibility"]
     except (KeyError, TypeError, json.JSONDecodeError):
         print(f"  GitHub returned an unexpected response for {OWNER}/{REPO}.")
-        return "error"
+        return GitHubRepositoryState("error")
 
-    return "empty" if is_empty else "nonempty"
+    if not isinstance(raw_visibility, str):
+        print(f"  GitHub returned an unexpected response for {OWNER}/{REPO}.")
+        return GitHubRepositoryState("error")
+
+    visibility = raw_visibility.lower()
+    if not isinstance(is_empty, bool) or visibility not in {
+        "internal",
+        "private",
+        "public",
+    }:
+        print(f"  GitHub returned an unexpected response for {OWNER}/{REPO}.")
+        return GitHubRepositoryState("error")
+
+    status = "empty" if is_empty else "nonempty"
+    return GitHubRepositoryState(status, visibility)
+
+
+def choose_pages_setup(visibility, *, interactive):
+    """Choose whether to publish documentation through GitHub Pages."""
+    if visibility == "public":
+        if interactive:
+            return prompt_yes_no("Enable GitHub Pages?", default=True)
+        return True
+
+    if not interactive:
+        print(f"  GitHub Pages will remain disabled for the {visibility} repository.")
+        return False
+
+    print()
+    print(
+        f"  Warning: GitHub Pages can publish a public website from a "
+        f"{visibility} repository."
+    )
+    print("  Pages for a non-public repository may also require a paid GitHub plan.")
+    return prompt_yes_no("Enable GitHub Pages anyway?")
 
 
 def print_github_plan(plan):
@@ -135,25 +190,30 @@ def print_github_plan(plan):
     print()
     print("GitHub setup plan:")
     if plan.existing:
-        print(f"  - connect to the empty repository https://github.com/{OWNER}/{REPO}")
+        print(
+            f"  - connect to the empty {plan.visibility} repository "
+            f"https://github.com/{OWNER}/{REPO}"
+        )
     else:
         print(
             f"  - create https://github.com/{OWNER}/{REPO} "
             f"as a {plan.visibility} repository"
         )
     print("  - initialize Git and create the first commit")
-    print("  - enable GitHub Pages")
+    if plan.enable_pages:
+        print("  - enable GitHub Pages (publishes a website)")
+    else:
+        print("  - leave GitHub Pages disabled")
     print("  - create the pypi environment")
     print("  - push main")
     print()
 
 
-def choose_github_setup():
+def choose_github_setup(mode):
     """Collect explicit consent and return a safe GitHub setup plan."""
-    mode = github_setup_mode()
     if mode == "skip":
         print("  GitHub setup skipped.")
-        return None
+        return GitHubSetupDecision(None)
 
     interactive = mode == "ask"
     if interactive:
@@ -163,44 +223,59 @@ def choose_github_setup():
                 "  Use `--github private` or `--github public` "
                 "to opt in during automation."
             )
-            return None
+            return GitHubSetupDecision(None)
         if not prompt_yes_no("Set up a GitHub repository now?"):
             print("  GitHub setup skipped.")
-            return None
+            return GitHubSetupDecision(None)
 
     if not github_cli_ready():
-        return None
+        return GitHubSetupDecision(None, failed=True)
 
     repository_state = github_repository_state()
-    if repository_state == "error":
-        return None
-    if repository_state == "nonempty":
+    if repository_state.status == "error":
+        return GitHubSetupDecision(None, failed=True)
+    if repository_state.status == "nonempty":
         print(f"  GitHub repository {OWNER}/{REPO} already exists and is not empty.")
         print("  For safety, the generator will not modify it automatically.")
-        return None
+        return GitHubSetupDecision(None, failed=True)
 
-    if repository_state == "empty":
+    if repository_state.status == "empty":
         if not interactive:
-            print(f"  GitHub repository {OWNER}/{REPO} already exists and is empty.")
+            print(
+                f"  GitHub repository {OWNER}/{REPO} already exists, is empty, "
+                f"and is {repository_state.visibility}."
+            )
             print(
                 "  Run interactively to confirm connecting to an existing repository."
             )
-            return None
+            return GitHubSetupDecision(None, failed=True)
         if not prompt_yes_no(
-            f"GitHub repository {OWNER}/{REPO} is empty. Connect to it?"
+            f"GitHub repository {OWNER}/{REPO} is empty and "
+            f"{repository_state.visibility}. Connect to it?"
         ):
             print("  Existing GitHub repository left unchanged.")
-            return None
-        plan = GitHubSetupPlan(existing=True, visibility=None)
+            return GitHubSetupDecision(None)
+        visibility = repository_state.visibility
+        if visibility is None:
+            print(f"  GitHub returned an unexpected response for {OWNER}/{REPO}.")
+            return GitHubSetupDecision(None, failed=True)
+        existing = True
     else:
         visibility = prompt_visibility() if interactive else mode
-        plan = GitHubSetupPlan(existing=False, visibility=visibility)
+        existing = False
+
+    enable_pages = choose_pages_setup(visibility, interactive=interactive)
+    plan = GitHubSetupPlan(
+        existing=existing,
+        visibility=visibility,
+        enable_pages=enable_pages,
+    )
 
     print_github_plan(plan)
     if interactive and not prompt_yes_no("Continue?"):
         print("  GitHub setup cancelled. No repository or Git commit was created.")
-        return None
-    return plan
+        return GitHubSetupDecision(None)
+    return GitHubSetupDecision(plan)
 
 
 def prepare_github_repository(plan):
@@ -382,23 +457,41 @@ def print_pypi_trusted_publisher_instructions():
 
 def main():
     """Run the confirmed setup flow after Cookiecutter renders the project."""
-    plan = choose_github_setup()
+    mode = github_setup_mode()
+    decision = choose_github_setup(mode)
+    plan = decision.plan
+    failed = decision.failed
+
     if plan is None:
         print("  Project generated locally without creating a Git commit.")
     elif not initialize_git():
         print("  Project generated, but Git setup did not complete.")
+        failed = True
     elif not prepare_github_repository(plan):
         print("  Project generated with a local commit, but no GitHub repository.")
+        failed = True
     else:
-        enable_github_pages()
-        create_pypi_environment()
-        if add_remote_and_push():
+        pages_ready = True
+        if plan.enable_pages:
+            pages_ready = enable_github_pages()
+        else:
+            print("  GitHub Pages setup skipped.")
+
+        environment_ready = create_pypi_environment()
+        push_succeeded = add_remote_and_push()
+        if push_succeeded:
             print_pypi_trusted_publisher_instructions()
         else:
             print("  Project generated, but the first GitHub push did not complete.")
+        failed = not (pages_ready and environment_ready and push_succeeded)
+
+    if failed:
+        print("Project files were generated, but GitHub setup did not complete.")
+        return 1
 
     print("Your Python package project has been created successfully!")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -7,8 +7,16 @@ import shutil
 import subprocess
 from typing import NamedTuple
 
-OWNER = "{{ cookiecutter.github_repo_owner }}"
-REPO = "{{ cookiecutter.package_name }}"
+OWNER = json.loads(
+    r"""
+{{ cookiecutter.github_repo_owner | tojson }}
+""".strip()
+)
+REPO = json.loads(
+    r"""
+{{ cookiecutter.package_name | tojson }}
+""".strip()
+)
 DESCRIPTION = json.loads(
     r"""
 {{ cookiecutter.project_short_description | tojson }}
@@ -302,8 +310,16 @@ def prepare_github_repository(plan):
     return False
 
 
-IMPORT_NAME = "{{ cookiecutter.import_name }}"
-FIRST_VERSION = "{{ cookiecutter.first_version }}"
+IMPORT_NAME = json.loads(
+    r"""
+{{ cookiecutter.import_name | tojson }}
+""".strip()
+)
+FIRST_VERSION = json.loads(
+    r"""
+{{ cookiecutter.first_version | tojson }}
+""".strip()
+)
 
 COMMIT_MESSAGE = f"""\
 https://github.com/audreyfeldroy/cookiecutter-pypackage scaffolding

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -25,6 +25,7 @@ DESCRIPTION = json.loads(
 
 GITHUB_SETUP_ENV = "COOKIECUTTER_PYPACKAGE_GITHUB"
 GITHUB_SETUP_MODES = {"ask", "skip", "private", "public"}
+GITHUB_HOST = "github.com"
 DOCS_DEPLOYMENT_VARIABLE = "DOCS_DEPLOYMENT_ENABLED"
 
 
@@ -53,12 +54,18 @@ class GitHubRepositoryState(NamedTuple):
 
 def run_command(*command):
     """Run a command without raising so the hook can report useful failures."""
+    environment = None
+    if command and command[0] == "gh":
+        environment = os.environ.copy()
+        environment["GH_HOST"] = GITHUB_HOST
+
     try:
         return subprocess.run(
             list(command),
             capture_output=True,
             text=True,
             check=False,
+            env=environment,
         )
     except OSError as error:
         return subprocess.CompletedProcess(
@@ -116,15 +123,28 @@ def github_cli_ready():
     """Check that GitHub CLI is installed and authenticated."""
     if not shutil.which("gh"):
         print("  GitHub CLI not found; GitHub setup will be skipped.")
-        print("  Install it from https://cli.github.com/ and run `gh auth login`.")
+        print(
+            "  Install it from https://cli.github.com/ and run "
+            f"`gh auth login --hostname {GITHUB_HOST}`."
+        )
         return False
 
-    result = run_command("gh", "auth", "status")
+    result = run_command(
+        "gh",
+        "auth",
+        "status",
+        "--hostname",
+        GITHUB_HOST,
+        "--active",
+    )
     if result.returncode == 0:
         return True
 
     print("  GitHub CLI is not authenticated; GitHub setup will be skipped.")
-    print("  Run `gh auth login`, then generate the project again.")
+    print(
+        f"  Run `gh auth login --hostname {GITHUB_HOST}`, "
+        "then generate the project again."
+    )
     return False
 
 
@@ -183,7 +203,7 @@ def github_git_protocol():
         "get",
         "git_protocol",
         "--host",
-        "github.com",
+        GITHUB_HOST,
     )
     if result.returncode != 0:
         print(f"  Could not read GitHub's Git protocol: {command_error(result)}")
@@ -194,15 +214,20 @@ def github_git_protocol():
         return protocol
 
     print(f"  GitHub CLI returned an unsupported Git protocol: {protocol or 'empty'}.")
-    print("  Set it with `gh config set git_protocol ssh --host github.com`.")
+    print(f"  Set it with `gh config set git_protocol ssh --host {GITHUB_HOST}`.")
     return None
 
 
 def github_remote_url(protocol):
     """Build a GitHub remote URL using the user's configured transport."""
     if protocol == "ssh":
-        return f"git@github.com:{OWNER}/{REPO}.git"
-    return f"https://github.com/{OWNER}/{REPO}.git"
+        return f"git@{GITHUB_HOST}:{OWNER}/{REPO}.git"
+    return f"https://{GITHUB_HOST}/{OWNER}/{REPO}.git"
+
+
+def github_repository_url():
+    """Build the canonical web URL for the target GitHub repository."""
+    return f"https://{GITHUB_HOST}/{OWNER}/{REPO}"
 
 
 def choose_pages_setup(visibility, *, interactive):
@@ -232,13 +257,10 @@ def print_github_plan(plan):
     if plan.existing:
         print(
             f"  - connect to the empty {plan.visibility} repository "
-            f"https://github.com/{OWNER}/{REPO}"
+            f"{github_repository_url()}"
         )
     else:
-        print(
-            f"  - create https://github.com/{OWNER}/{REPO} "
-            f"as a {plan.visibility} repository"
-        )
+        print(f"  - create {github_repository_url()} as a {plan.visibility} repository")
     print("  - initialize Git and create the first commit")
     if plan.enable_pages:
         print("  - enable GitHub Pages (publishes a website)")
@@ -328,7 +350,7 @@ def choose_github_setup(mode):
 def prepare_github_repository(plan):
     """Create the confirmed GitHub repository or select an empty one."""
     if plan.existing:
-        print(f"  Using existing empty repository: https://github.com/{OWNER}/{REPO}")
+        print(f"  Using existing empty repository: {github_repository_url()}")
         return True
 
     result = run_command(
@@ -341,7 +363,7 @@ def prepare_github_repository(plan):
         DESCRIPTION,
     )
     if result.returncode == 0:
-        print(f"  GitHub repository created: https://github.com/{OWNER}/{REPO}")
+        print(f"  GitHub repository created: {github_repository_url()}")
         return True
 
     print(f"  Could not create GitHub repository: {command_error(result)}")
@@ -438,7 +460,7 @@ def add_remote_and_push(protocol):
             )
             return False
 
-    print(f"  Pushed to https://github.com/{OWNER}/{REPO}")
+    print(f"  Pushed to {github_repository_url()}")
     return True
 
 

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,9 +1,14 @@
+import json
 import re
 import sys
 
 MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
 
-module_name = "{{ cookiecutter.import_name}}"
+module_name = json.loads(
+    r"""
+{{ cookiecutter.import_name | tojson }}
+""".strip()
+)
 
 if not re.match(MODULE_REGEX, module_name):
     print(

--- a/src/cookiecutter_pypackage/cli.py
+++ b/src/cookiecutter_pypackage/cli.py
@@ -4,16 +4,32 @@ Usage:
     uvx cookiecutter-pypackage
     uvx cookiecutter-pypackage --no-input
     uvx cookiecutter-pypackage --list-variables
+    uvx cookiecutter-pypackage --github private
+    uvx cookiecutter-pypackage --no-input --github private
     uvx cookiecutter-pypackage -o /path/to/output
     uvx cookiecutter-pypackage full_name="Audrey M. Roy Greenfeld" github_username=audreyfeldroy
     uvx cookiecutter-pypackage --no-input full_name="Audrey M. Roy Greenfeld" email="audreyfeldroy@example.com"
 """
 
 import json
+import os
+from enum import Enum
 from pathlib import Path
 
 import typer
 from cookiecutter.main import cookiecutter
+
+GITHUB_SETUP_ENV = "COOKIECUTTER_PYPACKAGE_GITHUB"
+
+
+class GitHubSetupMode(str, Enum):
+    """How the post-generation hook should handle GitHub setup."""
+
+    ASK = "ask"
+    SKIP = "skip"
+    PRIVATE = "private"
+    PUBLIC = "public"
+
 
 app = typer.Typer(
     help="Generate a Python package from the cookiecutter-pypackage template.",
@@ -47,6 +63,12 @@ def main(
         "--list-variables",
         help="List available template variables and their defaults",
     ),
+    github: GitHubSetupMode = typer.Option(
+        GitHubSetupMode.ASK,
+        "--github",
+        case_sensitive=False,
+        help="GitHub setup: ask, skip, private, or public",
+    ),
 ) -> None:
     """Generate a new Python package from the cookiecutter-pypackage template.
 
@@ -74,12 +96,24 @@ def main(
         key, value = arg.split("=", 1)
         extra_context[key] = value
 
-    cookiecutter(
-        str(template_dir),
-        output_dir=str(output_dir) if output_dir else ".",
-        no_input=no_input,
-        extra_context=extra_context or None,
-    )
+    github_mode = github
+    if no_input and github_mode is GitHubSetupMode.ASK:
+        github_mode = GitHubSetupMode.SKIP
+
+    previous_github_mode = os.environ.get(GITHUB_SETUP_ENV)
+    os.environ[GITHUB_SETUP_ENV] = github_mode.value
+    try:
+        cookiecutter(
+            str(template_dir),
+            output_dir=str(output_dir) if output_dir else ".",
+            no_input=no_input,
+            extra_context=extra_context or None,
+        )
+    finally:
+        if previous_github_mode is None:
+            os.environ.pop(GITHUB_SETUP_ENV, None)
+        else:
+            os.environ[GITHUB_SETUP_ENV] = previous_github_mode
 
 
 if __name__ == "__main__":

--- a/src/cookiecutter_pypackage/cli.py
+++ b/src/cookiecutter_pypackage/cli.py
@@ -17,6 +17,7 @@ from enum import Enum
 from pathlib import Path
 
 import typer
+from cookiecutter.exceptions import FailedHookException
 from cookiecutter.main import cookiecutter
 
 GITHUB_SETUP_ENV = "COOKIECUTTER_PYPACKAGE_GITHUB"
@@ -103,12 +104,22 @@ def main(
     previous_github_mode = os.environ.get(GITHUB_SETUP_ENV)
     os.environ[GITHUB_SETUP_ENV] = github_mode.value
     try:
-        cookiecutter(
-            str(template_dir),
-            output_dir=str(output_dir) if output_dir else ".",
-            no_input=no_input,
-            extra_context=extra_context or None,
-        )
+        try:
+            cookiecutter(
+                str(template_dir),
+                output_dir=str(output_dir) if output_dir else ".",
+                no_input=no_input,
+                extra_context=extra_context or None,
+                keep_project_on_failure=True,
+            )
+        except FailedHookException as error:
+            typer.echo(f"Error: {error}", err=True)
+            typer.echo(
+                "The generated project directory was kept so you can inspect "
+                "or recover the partial setup.",
+                err=True,
+            )
+            raise typer.Exit(code=1) from error
     finally:
         if previous_github_mode is None:
             os.environ.pop(GITHUB_SETUP_ENV, None)

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import shlex
 import subprocess
 import sys
@@ -95,6 +96,21 @@ def test_bake_builds_when_package_and_import_names_differ(cookies):
     assert (
         result.project_path / "dist" / "distribution_name-0.1.0-py3-none-any.whl"
     ).is_file()
+
+
+def test_bake_treats_import_name_as_data(cookies, tmp_path):
+    """Python-shaped import names are validated without being executed."""
+    marker = tmp_path / "import-name-was-executed"
+    import_name = (
+        '"; __import__("pathlib").Path('
+        f"{json.dumps(str(marker))}"
+        ').touch(); module_name = "valid'
+    )
+
+    result = cookies.bake(extra_context={"import_name": import_name})
+
+    assert result.exit_code != 0
+    assert not marker.exists()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="justfile not supported on Windows")

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -2,6 +2,7 @@ import datetime
 import shlex
 import subprocess
 import sys
+import tomllib
 
 import pytest
 
@@ -63,15 +64,22 @@ def test_bake_with_apostrophe_and_run_tests(cookies):
     run_inside_dir("uv run pytest", str(result.project_path))
 
 
-def test_bake_with_quotes_in_description(cookies):
-    """Ensure that double quotes in project_short_description produce valid TOML."""
-    result = cookies.bake(
-        extra_context={"project_short_description": 'A "quoted" description'}
-    )
+@pytest.mark.parametrize(
+    "description",
+    [
+        'A "quoted" description',
+        "A multiline\ndescription",
+        "A path ending in a backslash \\",
+    ],
+)
+def test_bake_preserves_description_in_valid_toml(cookies, description):
+    """Descriptions with TOML-sensitive characters remain valid and unchanged."""
+    result = cookies.bake(extra_context={"project_short_description": description})
     assert result.project_path.is_dir()
     assert result.exit_code == 0
-    content = (result.project_path / "pyproject.toml").read_text()
-    assert 'description = "A \\"quoted\\" description"' in content
+    with (result.project_path / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+    assert pyproject["project"]["description"] == description
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="justfile not supported on Windows")

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -103,3 +103,31 @@ def test_typing_classifier_in_pyproject(cookies):
     assert result.exit_code == 0
     content = (result.project_path / "pyproject.toml").read_text()
     assert '"Typing :: Typed"' in content
+
+
+def test_baked_workflows_support_private_repositories(cookies):
+    """Checkout and security workflows use safe private-repository defaults."""
+    result = cookies.bake()
+    assert result.exit_code == 0
+    workflows = result.project_path / ".github" / "workflows"
+
+    ci = (workflows / "ci.yml").read_text()
+    assert ci.count("contents: read") == 4
+
+    publish = (workflows / "publish.yml").read_text()
+    build_job = publish.split("  publish:", maxsplit=1)[0]
+    assert "contents: read" in build_job
+
+    codeql = (workflows / "codeql.yml").read_text()
+    private_code_security_opt_in = (
+        "${{ github.event.repository.private == false "
+        "|| vars.CODE_SECURITY_ENABLED == 'true' }}"
+    )
+    assert private_code_security_opt_in in codeql
+    assert "actions: read" in codeql
+    assert "contents: read" in codeql
+
+    zizmor = (workflows / "zizmor.yml").read_text()
+    assert f"advanced-security: {private_code_security_opt_in}" in zizmor
+    assert "actions: read" in zizmor
+    assert "contents: read" in zizmor

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -131,3 +131,6 @@ def test_baked_workflows_support_private_repositories(cookies):
     assert f"advanced-security: {private_code_security_opt_in}" in zizmor
     assert "actions: read" in zizmor
     assert "contents: read" in zizmor
+
+    docs = (workflows / "docs.yml").read_text()
+    assert "${{ vars.DOCS_DEPLOYMENT_ENABLED == 'true' }}" in docs

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -82,6 +82,21 @@ def test_bake_preserves_description_in_valid_toml(cookies, description):
     assert pyproject["project"]["description"] == description
 
 
+def test_bake_builds_when_package_and_import_names_differ(cookies):
+    """Hatchling packages the configured import directory without guessing."""
+    result = cookies.bake(
+        extra_context={
+            "package_name": "distribution-name",
+            "import_name": "importable_name",
+        }
+    )
+    assert result.exit_code == 0
+    run_inside_dir("uv build", str(result.project_path))
+    assert (
+        result.project_path / "dist" / "distribution_name-0.1.0-py3-none-any.whl"
+    ).is_file()
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="justfile not supported on Windows")
 def test_just_list(cookies):
     result = cookies.bake()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,9 +82,11 @@ def test_explicit_github_mode_is_forwarded_and_environment_restored(
     monkeypatch.setattr(cli, "_find_template_dir", lambda: tmp_path)
     monkeypatch.setenv(cli.GITHUB_SETUP_ENV, "private")
     observed_modes = []
+    observed_options = []
 
     def fake_cookiecutter(*args, **kwargs):
         observed_modes.append(os.environ[cli.GITHUB_SETUP_ENV])
+        observed_options.append(kwargs)
 
     monkeypatch.setattr(cli, "cookiecutter", fake_cookiecutter)
     result = CliRunner().invoke(
@@ -94,7 +96,31 @@ def test_explicit_github_mode_is_forwarded_and_environment_restored(
 
     assert result.exit_code == 0
     assert observed_modes == ["public"]
+    assert observed_options[0]["keep_project_on_failure"] is True
     assert os.environ[cli.GITHUB_SETUP_ENV] == "private"
+
+
+def test_failed_github_hook_is_detectable_and_keeps_generated_project(
+    monkeypatch, tmp_path
+):
+    """A failed explicit setup exits nonzero without deleting generated files."""
+    (tmp_path / "cookiecutter.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "_find_template_dir", lambda: tmp_path)
+
+    def fake_cookiecutter(*args, **kwargs):
+        assert kwargs["keep_project_on_failure"] is True
+        raise cli.FailedHookException("post-generation hook failed")
+
+    monkeypatch.setattr(cli, "cookiecutter", fake_cookiecutter)
+    result = CliRunner().invoke(
+        cli.app,
+        ["--no-input", "--github", "private"],
+    )
+
+    assert result.exit_code == 1
+    assert "post-generation hook failed" in result.output
+    assert "project directory was kept" in result.output
+    assert cli.GITHUB_SETUP_ENV not in os.environ
 
 
 def test_extra_context_single_value(cookies):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ forwarding extra_context values when generating projects.
 """
 
 import json
+import os
 
 from typer.testing import CliRunner
 
@@ -54,6 +55,46 @@ def test_list_variables(monkeypatch, tmp_path):
         "  full_name (default: 'Example User')",
         "  package_name (default: '{{ cookiecutter.project_name }}')",
     ]
+
+
+def test_no_input_skips_github_setup_by_default(monkeypatch, tmp_path):
+    """Non-interactive generation requires an explicit GitHub opt-in."""
+    (tmp_path / "cookiecutter.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "_find_template_dir", lambda: tmp_path)
+    observed_modes = []
+
+    def fake_cookiecutter(*args, **kwargs):
+        observed_modes.append(os.environ[cli.GITHUB_SETUP_ENV])
+
+    monkeypatch.setattr(cli, "cookiecutter", fake_cookiecutter)
+    result = CliRunner().invoke(cli.app, ["--no-input"])
+
+    assert result.exit_code == 0
+    assert observed_modes == ["skip"]
+    assert cli.GITHUB_SETUP_ENV not in os.environ
+
+
+def test_explicit_github_mode_is_forwarded_and_environment_restored(
+    monkeypatch, tmp_path
+):
+    """The CLI forwards explicit consent without leaking process state."""
+    (tmp_path / "cookiecutter.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "_find_template_dir", lambda: tmp_path)
+    monkeypatch.setenv(cli.GITHUB_SETUP_ENV, "private")
+    observed_modes = []
+
+    def fake_cookiecutter(*args, **kwargs):
+        observed_modes.append(os.environ[cli.GITHUB_SETUP_ENV])
+
+    monkeypatch.setattr(cli, "cookiecutter", fake_cookiecutter)
+    result = CliRunner().invoke(
+        cli.app,
+        ["--no-input", "--github", "public"],
+    )
+
+    assert result.exit_code == 0
+    assert observed_modes == ["public"]
+    assert os.environ[cli.GITHUB_SETUP_ENV] == "private"
 
 
 def test_extra_context_single_value(cookies):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,10 +6,20 @@ forwarding extra_context values when generating projects.
 
 import json
 import os
+from pathlib import Path
 
 from typer.testing import CliRunner
 
 from cookiecutter_pypackage import cli
+
+
+def test_readme_direct_cookiecutter_command_keeps_failed_projects():
+    """The documented fallback preserves output when a hook fails."""
+    readme = (Path(__file__).parents[1] / "README.md").read_text(encoding="utf-8")
+
+    assert (
+        "cookiecutter --keep-project-on-failure gh:audreyfeldroy/cookiecutter-pypackage"
+    ) in readme
 
 
 def test_find_template_dir_in_source_checkout(monkeypatch, tmp_path):

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -357,6 +357,71 @@ def test_push_uses_github_cli_git_protocol(hook, monkeypatch, protocol, remote_u
     assert ("git", "remote", "add", "origin", remote_url) in commands
 
 
+def test_https_setup_configures_git_credentials(hook, monkeypatch, capsys):
+    """HTTPS automation teaches Git to use the authenticated GitHub CLI."""
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    assert hook.configure_git_credentials("https") is True
+    assert (
+        "gh",
+        "auth",
+        "setup-git",
+        "--hostname",
+        hook.GITHUB_HOST,
+    ) in commands
+    assert "Git configured to use GitHub CLI credentials" in capsys.readouterr().out
+
+
+def test_ssh_setup_does_not_change_git_credentials(hook, monkeypatch):
+    """SSH setup leaves the user's Git credential helper unchanged."""
+
+    def fail_run_command(*command):
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(hook, "run_command", fail_run_command)
+
+    assert hook.configure_git_credentials("ssh") is True
+
+
+def test_https_credential_failure_stops_before_git_or_github_writes(
+    hook, monkeypatch, capsys
+):
+    """A credential-helper failure does not create local or remote repository state."""
+    answers = iter(["yes", "", "", "yes"])
+    monkeypatch.setattr(hook.os, "isatty", lambda _: True)
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        if command[:3] == ("gh", "config", "get"):
+            return completed(command, stdout="https\n")
+        if command[:3] == ("gh", "auth", "setup-git"):
+            return completed(command, returncode=1, stderr="credential helper failed")
+        return successful(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    assert hook.main() == 1
+    assert not any(command[0] == "git" for command in commands)
+    assert not any(command[:3] == ("gh", "repo", "create") for command in commands)
+    output = capsys.readouterr().out
+    assert "Could not configure Git credentials for HTTPS" in output
+    assert "Git credential setup did not complete" in output
+
+
 def test_commit_failure_reports_partial_local_git_state(hook, monkeypatch, capsys):
     """A late local failure does not claim that no local repository was created."""
     commands = []

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -10,18 +10,18 @@ from cookiecutter.generate import create_env_with_context
 HOOK_PATH = Path(__file__).parents[1] / "hooks" / "post_gen_project.py"
 
 
-def load_hook(tmp_path, description="Example project"):
+def load_hook(tmp_path, **overrides):
     """Render and load the hook exactly as Cookiecutter does."""
     source = HOOK_PATH.read_text(encoding="utf-8")
-    context = {
-        "cookiecutter": {
-            "github_repo_owner": "example-owner",
-            "package_name": "example-repo",
-            "project_short_description": description,
-            "import_name": "example_repo",
-            "first_version": "0.1.0",
-        }
+    values = {
+        "github_repo_owner": "example-owner",
+        "package_name": "example-repo",
+        "project_short_description": "Example project",
+        "import_name": "example_repo",
+        "first_version": "0.1.0",
     }
+    values.update(overrides)
+    context = {"cookiecutter": values}
     rendered = create_env_with_context(context).from_string(source).render(**context)
     rendered_path = tmp_path / "post_gen_project.py"
     rendered_path.write_text(rendered, encoding="utf-8")
@@ -328,6 +328,23 @@ def test_pages_failure_is_reported_without_false_success(hook, monkeypatch, caps
 )
 def test_description_is_rendered_as_a_safe_string_literal(tmp_path, description):
     """Rendered descriptions preserve newlines and backslashes without syntax errors."""
-    hook = load_hook(tmp_path, description)
+    hook = load_hook(tmp_path, project_short_description=description)
 
     assert hook.DESCRIPTION == description
+
+
+def test_all_hook_template_values_are_rendered_safely(tmp_path):
+    """Quotes, backslashes, and newlines cannot corrupt the rendered hook."""
+    values = {
+        "github_repo_owner": 'owner"\\\nnext',
+        "package_name": 'repo"\\\nnext',
+        "import_name": 'module"\\\nnext',
+        "first_version": '1.0"\\\nnext',
+    }
+
+    hook = load_hook(tmp_path, **values)
+
+    assert hook.OWNER == values["github_repo_owner"]
+    assert hook.REPO == values["package_name"]
+    assert hook.IMPORT_NAME == values["import_name"]
+    assert hook.FIRST_VERSION == values["first_version"]

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -5,21 +5,44 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from jinja2 import Environment
 
 HOOK_PATH = Path(__file__).parents[1] / "hooks" / "post_gen_project.py"
 
 
-@pytest.fixture
-def hook(monkeypatch):
-    """Load the hook as a module with predictable rendered values."""
-    spec = importlib.util.spec_from_file_location("post_gen_project_test", HOOK_PATH)
+def load_hook(tmp_path, description="Example project"):
+    """Render and load the hook exactly as Cookiecutter does."""
+    source = HOOK_PATH.read_text(encoding="utf-8")
+    rendered = (
+        Environment(keep_trailing_newline=True)
+        .from_string(source)
+        .render(
+            cookiecutter={
+                "github_repo_owner": "example-owner",
+                "package_name": "example-repo",
+                "project_short_description": description,
+                "import_name": "example_repo",
+                "first_version": "0.1.0",
+            }
+        )
+    )
+    rendered_path = tmp_path / "post_gen_project.py"
+    rendered_path.write_text(rendered, encoding="utf-8")
+
+    spec = importlib.util.spec_from_file_location(
+        "rendered_post_gen_project", rendered_path
+    )
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    monkeypatch.setattr(module, "OWNER", "example-owner")
-    monkeypatch.setattr(module, "REPO", "example-repo")
-    monkeypatch.setattr(module, "DESCRIPTION", "Example project")
+    return module
+
+
+@pytest.fixture
+def hook(monkeypatch, tmp_path):
+    """Load the hook as a module with predictable rendered values."""
+    module = load_hook(tmp_path)
     monkeypatch.setattr(module.shutil, "which", lambda _: "/usr/bin/gh")
     return module
 
@@ -52,7 +75,7 @@ def test_declining_setup_has_no_git_or_github_side_effects(hook, monkeypatch, ca
 
 def test_visibility_reprompts_and_defaults_to_private(hook, monkeypatch, capsys):
     """Invalid visibility cannot accidentally create a public repository."""
-    answers = iter(["yes", "privte", "", "yes"])
+    answers = iter(["yes", "privte", "", "", "yes"])
     monkeypatch.setattr(hook.os, "isatty", lambda _: True)
     monkeypatch.setattr("builtins.input", lambda _: next(answers))
     commands = []
@@ -75,12 +98,19 @@ def test_visibility_reprompts_and_defaults_to_private(hook, monkeypatch, capsys)
     )
     assert "--private" in create_command
     assert "--public" not in create_command
-    assert "Please enter private or public." in capsys.readouterr().out
+    assert not any(
+        command[:2] == ("gh", "api") and command[2].endswith("/pages")
+        for command in commands
+    )
+    output = capsys.readouterr().out
+    assert "Please enter private or public." in output
+    assert "can publish a public website from a private repository" in output
+    assert "leave GitHub Pages disabled" in output
 
 
 def test_final_confirmation_cancels_before_any_write(hook, monkeypatch, capsys):
     """The plan remains read-only until the final confirmation."""
-    answers = iter(["yes", "", "no"])
+    answers = iter(["yes", "", "", "no"])
     monkeypatch.setattr(hook.os, "isatty", lambda _: True)
     monkeypatch.setattr("builtins.input", lambda _: next(answers))
     commands = []
@@ -105,15 +135,24 @@ def test_final_confirmation_cancels_before_any_write(hook, monkeypatch, capsys):
 
 def test_empty_existing_repository_requires_separate_consent(hook, monkeypatch, capsys):
     """An empty repository is connected only after a second explicit yes."""
-    answers = iter(["yes", "yes", "yes"])
+    answers = iter(["yes", "yes", "", "yes"])
+    prompts = []
     monkeypatch.setattr(hook.os, "isatty", lambda _: True)
-    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+
+    def fake_input(prompt):
+        prompts.append(prompt)
+        return next(answers)
+
+    monkeypatch.setattr("builtins.input", fake_input)
     commands = []
 
     def fake_run_command(*command):
         commands.append(command)
         if command[:3] == ("gh", "repo", "view"):
-            return completed(command, stdout='{"isEmpty": true}')
+            return completed(
+                command,
+                stdout='{"isEmpty": true, "visibility": "PRIVATE"}',
+            )
         return completed(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
@@ -123,6 +162,8 @@ def test_empty_existing_repository_requires_separate_consent(hook, monkeypatch, 
     assert ("git", "push", "-u", "origin", "main") in commands
     output = capsys.readouterr().out
     assert "Using existing empty repository" in output
+    assert any("empty and private" in prompt for prompt in prompts)
+    assert "connect to the empty private repository" in output
 
 
 def test_nonempty_existing_repository_is_never_modified(hook, monkeypatch, capsys):
@@ -135,7 +176,10 @@ def test_nonempty_existing_repository_is_never_modified(hook, monkeypatch, capsy
     def fake_run_command(*command):
         commands.append(command)
         if command[:3] == ("gh", "repo", "view"):
-            return completed(command, stdout='{"isEmpty": false}')
+            return completed(
+                command,
+                stdout='{"isEmpty": false, "visibility": "PUBLIC"}',
+            )
         return completed(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
@@ -163,19 +207,51 @@ def test_explicit_public_mode_supports_noninteractive_automation(hook, monkeypat
         return completed(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
-    hook.main()
+    assert hook.main() == 0
 
     create_command = next(
         command for command in commands if command[:3] == ("gh", "repo", "create")
     )
     assert "--public" in create_command
+    assert any(
+        command[:2] == ("gh", "api") and command[2].endswith("/pages")
+        for command in commands
+    )
+
+
+def test_explicit_private_mode_leaves_pages_disabled(hook, monkeypatch, capsys):
+    """Private automation does not silently publish a public Pages site."""
+    monkeypatch.setenv(hook.GITHUB_SETUP_ENV, "private")
+    monkeypatch.setattr(hook.os, "isatty", lambda _: False)
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+    assert hook.main() == 0
+
+    assert not any(
+        command[:2] == ("gh", "api") and command[2].endswith("/pages")
+        for command in commands
+    )
+    output = capsys.readouterr().out
+    assert "Pages will remain disabled for the private repository" in output
+    assert "leave GitHub Pages disabled" in output
 
 
 def test_remote_settings_precede_first_push_and_push_failure_is_reported(
     hook, monkeypatch, capsys
 ):
     """The first workflow starts configured, and a rejected push stays visible."""
-    answers = iter(["yes", "", "yes"])
+    answers = iter(["yes", "", "yes", "yes"])
     monkeypatch.setattr(hook.os, "isatty", lambda _: True)
     monkeypatch.setattr("builtins.input", lambda _: next(answers))
     commands = []
@@ -193,7 +269,7 @@ def test_remote_settings_precede_first_push_and_push_failure_is_reported(
         return completed(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
-    hook.main()
+    assert hook.main() == 1
 
     push_index = commands.index(("git", "push", "-u", "origin", "main"))
     api_indexes = [
@@ -204,6 +280,31 @@ def test_remote_settings_precede_first_push_and_push_failure_is_reported(
     output = capsys.readouterr().out
     assert "Could not push main to GitHub: push rejected" in output
     assert "To publish to PyPI" not in output
+    assert "GitHub setup did not complete" in output
+
+
+def test_explicit_automation_failure_returns_nonzero(hook, monkeypatch, capsys):
+    """Automation can reliably detect a requested GitHub setup failure."""
+    monkeypatch.setenv(hook.GITHUB_SETUP_ENV, "public")
+    monkeypatch.setattr(hook.os, "isatty", lambda _: False)
+
+    def fake_run_command(*command):
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        if command[:3] == ("gh", "repo", "create"):
+            return completed(command, returncode=1, stderr="permission denied")
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    assert hook.main() == 1
+    output = capsys.readouterr().out
+    assert "Could not create GitHub repository: permission denied" in output
+    assert "GitHub setup did not complete" in output
 
 
 def test_pages_failure_is_reported_without_false_success(hook, monkeypatch, capsys):
@@ -218,3 +319,18 @@ def test_pages_failure_is_reported_without_false_success(hook, monkeypatch, caps
     output = capsys.readouterr().out
     assert "Could not configure GitHub Pages" in output
     assert "Pages enabled" not in output
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        "Ends with a backslash \\",
+        "Spans two lines\nwithout breaking the hook",
+        r"Uses a Windows path C:\new\tools",
+    ],
+)
+def test_description_is_rendered_as_a_safe_string_literal(tmp_path, description):
+    """Rendered descriptions preserve newlines and backslashes without syntax errors."""
+    hook = load_hook(tmp_path, description)
+
+    assert hook.DESCRIPTION == description

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -54,6 +54,13 @@ def completed(command, returncode=0, *, stdout="", stderr=""):
     )
 
 
+def successful(command):
+    """Return realistic output for commands that the happy path reads."""
+    if command[:3] == ("gh", "config", "get"):
+        return completed(command, stdout="ssh\n")
+    return completed(command)
+
+
 def test_declining_setup_has_no_git_or_github_side_effects(hook, monkeypatch, capsys):
     """The default answer leaves the generated files entirely local."""
     monkeypatch.setattr(hook.os, "isatty", lambda _: True)
@@ -85,7 +92,7 @@ def test_visibility_reprompts_and_defaults_to_private(hook, monkeypatch, capsys)
                 returncode=1,
                 stderr="Could not resolve to a Repository",
             )
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
     hook.main()
@@ -120,7 +127,7 @@ def test_final_confirmation_cancels_before_any_write(hook, monkeypatch, capsys):
                 returncode=1,
                 stderr="Could not resolve to a Repository",
             )
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
     hook.main()
@@ -150,7 +157,7 @@ def test_empty_existing_repository_requires_separate_consent(hook, monkeypatch, 
                 command,
                 stdout='{"isEmpty": true, "visibility": "PRIVATE"}',
             )
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
     hook.main()
@@ -177,7 +184,7 @@ def test_nonempty_existing_repository_is_never_modified(hook, monkeypatch, capsy
                 command,
                 stdout='{"isEmpty": false, "visibility": "PUBLIC"}',
             )
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
     hook.main()
@@ -201,7 +208,7 @@ def test_explicit_public_mode_supports_noninteractive_automation(hook, monkeypat
                 returncode=1,
                 stderr="Could not resolve to a Repository",
             )
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
     assert hook.main() == 0
@@ -230,7 +237,7 @@ def test_explicit_private_mode_leaves_pages_disabled(hook, monkeypatch, capsys):
                 returncode=1,
                 stderr="Could not resolve to a Repository",
             )
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
     assert hook.main() == 0
@@ -242,6 +249,45 @@ def test_explicit_private_mode_leaves_pages_disabled(hook, monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "Pages will remain disabled for the private repository" in output
     assert "leave GitHub Pages disabled" in output
+
+
+@pytest.mark.parametrize(
+    ("protocol", "remote_url"),
+    [
+        ("ssh", "git@github.com:example-owner/example-repo.git"),
+        ("https", "https://github.com/example-owner/example-repo.git"),
+    ],
+)
+def test_push_uses_github_cli_git_protocol(hook, monkeypatch, protocol, remote_url):
+    """The first push uses the transport already configured in GitHub CLI."""
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "config", "get"):
+            return completed(command, stdout=f"{protocol}\n")
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    configured_protocol = hook.github_git_protocol()
+    assert configured_protocol == protocol
+    assert hook.add_remote_and_push(configured_protocol) is True
+    assert ("git", "remote", "add", "origin", remote_url) in commands
+
+
+def test_unsupported_git_protocol_stops_before_writes(hook, monkeypatch, capsys):
+    """An unexpected GitHub CLI configuration is reported before setup writes."""
+
+    def fake_run_command(*command):
+        return completed(command, stdout="file\n")
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    assert hook.github_git_protocol() is None
+    output = capsys.readouterr().out
+    assert "unsupported Git protocol: file" in output
+    assert "gh config set git_protocol ssh" in output
 
 
 def test_remote_settings_precede_first_push_and_push_failure_is_reported(
@@ -263,7 +309,7 @@ def test_remote_settings_precede_first_push_and_push_failure_is_reported(
             )
         if command[:2] == ("git", "push"):
             return completed(command, returncode=1, stderr="push rejected")
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
     assert hook.main() == 1
@@ -294,7 +340,7 @@ def test_explicit_automation_failure_returns_nonzero(hook, monkeypatch, capsys):
             )
         if command[:3] == ("gh", "repo", "create"):
             return completed(command, returncode=1, stderr="permission denied")
-        return completed(command)
+        return successful(command)
 
     monkeypatch.setattr(hook, "run_command", fake_run_command)
 

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -1,0 +1,220 @@
+"""Tests for the post-generation GitHub setup flow."""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).parents[1] / "hooks" / "post_gen_project.py"
+
+
+@pytest.fixture
+def hook(monkeypatch):
+    """Load the hook as a module with predictable rendered values."""
+    spec = importlib.util.spec_from_file_location("post_gen_project_test", HOOK_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "OWNER", "example-owner")
+    monkeypatch.setattr(module, "REPO", "example-repo")
+    monkeypatch.setattr(module, "DESCRIPTION", "Example project")
+    monkeypatch.setattr(module.shutil, "which", lambda _: "/usr/bin/gh")
+    return module
+
+
+def completed(command, returncode=0, *, stdout="", stderr=""):
+    """Build a subprocess result for a mocked command."""
+    return subprocess.CompletedProcess(
+        args=command,
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_declining_setup_has_no_git_or_github_side_effects(hook, monkeypatch, capsys):
+    """The default answer leaves the generated files entirely local."""
+    monkeypatch.setattr(hook.os, "isatty", lambda _: True)
+    monkeypatch.setattr("builtins.input", lambda _: "")
+
+    def fail_run_command(*command):
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(hook, "run_command", fail_run_command)
+    hook.main()
+
+    output = capsys.readouterr().out
+    assert "GitHub setup skipped." in output
+    assert "without creating a Git commit" in output
+
+
+def test_visibility_reprompts_and_defaults_to_private(hook, monkeypatch, capsys):
+    """Invalid visibility cannot accidentally create a public repository."""
+    answers = iter(["yes", "privte", "", "yes"])
+    monkeypatch.setattr(hook.os, "isatty", lambda _: True)
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+    hook.main()
+
+    create_command = next(
+        command for command in commands if command[:3] == ("gh", "repo", "create")
+    )
+    assert "--private" in create_command
+    assert "--public" not in create_command
+    assert "Please enter private or public." in capsys.readouterr().out
+
+
+def test_final_confirmation_cancels_before_any_write(hook, monkeypatch, capsys):
+    """The plan remains read-only until the final confirmation."""
+    answers = iter(["yes", "", "no"])
+    monkeypatch.setattr(hook.os, "isatty", lambda _: True)
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+    hook.main()
+
+    assert not any(command[:3] == ("gh", "repo", "create") for command in commands)
+    assert not any(command[0] == "git" for command in commands)
+    assert "No repository or Git commit was created" in capsys.readouterr().out
+
+
+def test_empty_existing_repository_requires_separate_consent(hook, monkeypatch, capsys):
+    """An empty repository is connected only after a second explicit yes."""
+    answers = iter(["yes", "yes", "yes"])
+    monkeypatch.setattr(hook.os, "isatty", lambda _: True)
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(command, stdout='{"isEmpty": true}')
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+    hook.main()
+
+    assert not any(command[:3] == ("gh", "repo", "create") for command in commands)
+    assert ("git", "push", "-u", "origin", "main") in commands
+    output = capsys.readouterr().out
+    assert "Using existing empty repository" in output
+
+
+def test_nonempty_existing_repository_is_never_modified(hook, monkeypatch, capsys):
+    """The automatic flow refuses to push to a nonempty repository."""
+    answers = iter(["yes"])
+    monkeypatch.setattr(hook.os, "isatty", lambda _: True)
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(command, stdout='{"isEmpty": false}')
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+    hook.main()
+
+    assert not any(command[0] == "git" for command in commands)
+    assert not any(command[:3] == ("gh", "repo", "create") for command in commands)
+    assert "will not modify it automatically" in capsys.readouterr().out
+
+
+def test_explicit_public_mode_supports_noninteractive_automation(hook, monkeypatch):
+    """The CLI flag itself is sufficient consent during automation."""
+    monkeypatch.setenv(hook.GITHUB_SETUP_ENV, "public")
+    monkeypatch.setattr(hook.os, "isatty", lambda _: False)
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+    hook.main()
+
+    create_command = next(
+        command for command in commands if command[:3] == ("gh", "repo", "create")
+    )
+    assert "--public" in create_command
+
+
+def test_remote_settings_precede_first_push_and_push_failure_is_reported(
+    hook, monkeypatch, capsys
+):
+    """The first workflow starts configured, and a rejected push stays visible."""
+    answers = iter(["yes", "", "yes"])
+    monkeypatch.setattr(hook.os, "isatty", lambda _: True)
+    monkeypatch.setattr("builtins.input", lambda _: next(answers))
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:3] == ("gh", "repo", "view"):
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        if command[:2] == ("git", "push"):
+            return completed(command, returncode=1, stderr="push rejected")
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+    hook.main()
+
+    push_index = commands.index(("git", "push", "-u", "origin", "main"))
+    api_indexes = [
+        index for index, command in enumerate(commands) if command[:2] == ("gh", "api")
+    ]
+    assert api_indexes
+    assert all(index < push_index for index in api_indexes)
+    output = capsys.readouterr().out
+    assert "Could not push main to GitHub: push rejected" in output
+    assert "To publish to PyPI" not in output
+
+
+def test_pages_failure_is_reported_without_false_success(hook, monkeypatch, capsys):
+    """Failed Pages API calls do not claim that Pages was enabled."""
+
+    def fake_run_command(*command):
+        return completed(command, returncode=1, stderr="permission denied")
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    assert hook.enable_github_pages() is False
+    output = capsys.readouterr().out
+    assert "Could not configure GitHub Pages" in output
+    assert "Pages enabled" not in output

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -221,6 +221,16 @@ def test_explicit_public_mode_supports_noninteractive_automation(hook, monkeypat
         command[:2] == ("gh", "api") and command[2].endswith("/pages")
         for command in commands
     )
+    assert (
+        "gh",
+        "variable",
+        "set",
+        "DOCS_DEPLOYMENT_ENABLED",
+        "--repo",
+        "example-owner/example-repo",
+        "--body",
+        "true",
+    ) in commands
 
 
 def test_explicit_private_mode_leaves_pages_disabled(hook, monkeypatch, capsys):
@@ -246,9 +256,20 @@ def test_explicit_private_mode_leaves_pages_disabled(hook, monkeypatch, capsys):
         command[:2] == ("gh", "api") and command[2].endswith("/pages")
         for command in commands
     )
+    assert (
+        "gh",
+        "variable",
+        "set",
+        "DOCS_DEPLOYMENT_ENABLED",
+        "--repo",
+        "example-owner/example-repo",
+        "--body",
+        "false",
+    ) in commands
     output = capsys.readouterr().out
     assert "Pages will remain disabled for the private repository" in output
     assert "leave GitHub Pages disabled" in output
+    assert "documentation deployment workflow paused" in output.lower()
 
 
 @pytest.mark.parametrize(
@@ -315,11 +336,13 @@ def test_remote_settings_precede_first_push_and_push_failure_is_reported(
     assert hook.main() == 1
 
     push_index = commands.index(("git", "push", "-u", "origin", "main"))
-    api_indexes = [
-        index for index, command in enumerate(commands) if command[:2] == ("gh", "api")
+    settings_indexes = [
+        index
+        for index, command in enumerate(commands)
+        if command[:2] == ("gh", "api") or command[:3] == ("gh", "variable", "set")
     ]
-    assert api_indexes
-    assert all(index < push_index for index in api_indexes)
+    assert settings_indexes
+    assert all(index < push_index for index in settings_indexes)
     output = capsys.readouterr().out
     assert "Could not push main to GitHub: push rejected" in output
     assert "To publish to PyPI" not in output
@@ -362,6 +385,25 @@ def test_pages_failure_is_reported_without_false_success(hook, monkeypatch, caps
     output = capsys.readouterr().out
     assert "Could not configure GitHub Pages" in output
     assert "Pages enabled" not in output
+
+
+def test_docs_deployment_failure_is_reported_with_recovery_command(
+    hook, monkeypatch, capsys
+):
+    """A failed repository-variable write includes an exact recovery command."""
+
+    def fake_run_command(*command):
+        return completed(command, returncode=1, stderr="permission denied")
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    assert hook.configure_docs_deployment(False) is False
+    output = capsys.readouterr().out
+    assert "Could not configure the documentation deployment workflow" in output
+    assert (
+        "gh variable set DOCS_DEPLOYMENT_ENABLED "
+        "--repo example-owner/example-repo --body false"
+    ) in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -233,6 +233,66 @@ def test_explicit_public_mode_supports_noninteractive_automation(hook, monkeypat
     ) in commands
 
 
+def test_github_setup_pins_one_host_when_ambient_host_differs(
+    hook, monkeypatch, capsys
+):
+    """Every GitHub read, write, display, and push targets GitHub.com."""
+    monkeypatch.setenv("GH_HOST", "github.corp.example")
+    monkeypatch.setenv(hook.GITHUB_SETUP_ENV, "public")
+    monkeypatch.setattr(hook.os, "isatty", lambda _: False)
+    calls = []
+
+    def fake_subprocess_run(command, **kwargs):
+        calls.append((tuple(command), kwargs))
+        if command[:3] == ["gh", "repo", "view"]:
+            return completed(
+                command,
+                returncode=1,
+                stderr="Could not resolve to a Repository",
+            )
+        if command[:3] == ["gh", "config", "get"]:
+            return completed(command, stdout="ssh\n")
+        return completed(command)
+
+    monkeypatch.setattr(hook.subprocess, "run", fake_subprocess_run)
+
+    assert hook.main() == 0
+
+    github_calls = [
+        (command, kwargs) for command, kwargs in calls if command[0] == "gh"
+    ]
+    assert github_calls
+    assert {command[1] for command, _ in github_calls} == {
+        "api",
+        "auth",
+        "config",
+        "repo",
+        "variable",
+    }
+    assert all(
+        kwargs["env"]["GH_HOST"] == hook.GITHUB_HOST for _, kwargs in github_calls
+    )
+    assert hook.os.environ["GH_HOST"] == "github.corp.example"
+    assert (
+        "gh",
+        "auth",
+        "status",
+        "--hostname",
+        hook.GITHUB_HOST,
+        "--active",
+    ) in [command for command, _ in github_calls]
+    assert (
+        "git",
+        "remote",
+        "add",
+        "origin",
+        "git@github.com:example-owner/example-repo.git",
+    ) in [command for command, _ in calls]
+    output = capsys.readouterr().out
+    assert "https://github.com/example-owner/example-repo" in output
+    assert "github.corp.example" not in output
+
+
 def test_explicit_private_mode_leaves_pages_disabled(hook, monkeypatch, capsys):
     """Private automation does not silently publish a public Pages site."""
     monkeypatch.setenv(hook.GITHUB_SETUP_ENV, "private")

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from jinja2 import Environment
+from cookiecutter.generate import create_env_with_context
 
 HOOK_PATH = Path(__file__).parents[1] / "hooks" / "post_gen_project.py"
 
@@ -13,19 +13,16 @@ HOOK_PATH = Path(__file__).parents[1] / "hooks" / "post_gen_project.py"
 def load_hook(tmp_path, description="Example project"):
     """Render and load the hook exactly as Cookiecutter does."""
     source = HOOK_PATH.read_text(encoding="utf-8")
-    rendered = (
-        Environment(keep_trailing_newline=True)
-        .from_string(source)
-        .render(
-            cookiecutter={
-                "github_repo_owner": "example-owner",
-                "package_name": "example-repo",
-                "project_short_description": description,
-                "import_name": "example_repo",
-                "first_version": "0.1.0",
-            }
-        )
-    )
+    context = {
+        "cookiecutter": {
+            "github_repo_owner": "example-owner",
+            "package_name": "example-repo",
+            "project_short_description": description,
+            "import_name": "example_repo",
+            "first_version": "0.1.0",
+        }
+    }
+    rendered = create_env_with_context(context).from_string(source).render(**context)
     rendered_path = tmp_path / "post_gen_project.py"
     rendered_path.write_text(rendered, encoding="utf-8")
 

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -297,6 +297,29 @@ def test_push_uses_github_cli_git_protocol(hook, monkeypatch, protocol, remote_u
     assert ("git", "remote", "add", "origin", remote_url) in commands
 
 
+def test_commit_failure_reports_partial_local_git_state(hook, monkeypatch, capsys):
+    """A late local failure does not claim that no local repository was created."""
+    commands = []
+
+    def fake_run_command(*command):
+        commands.append(command)
+        if command[:2] == ("git", "commit"):
+            return completed(command, returncode=1, stderr="Author identity unknown")
+        return completed(command)
+
+    monkeypatch.setattr(hook, "run_command", fake_run_command)
+
+    assert hook.initialize_git() is False
+    assert commands[0] == ("git", "init", "-b", "main")
+    assert commands[1] == ("git", "add", ".")
+    output = capsys.readouterr().out
+    assert "Could not create the first Git commit: Author identity unknown" in output
+    assert (
+        "GitHub setup stopped before creating or modifying a GitHub repository."
+        in output
+    )
+
+
 def test_unsupported_git_protocol_stops_before_writes(hook, monkeypatch, capsys):
     """An unexpected GitHub CLI configuration is reported before setup writes."""
 

--- a/{{cookiecutter.package_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -38,6 +40,8 @@ jobs:
   type-check:
     name: Type check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -51,6 +55,8 @@ jobs:
   test:
     name: Test (Python ${{ "{{" }} matrix.python-version {{ "}}" }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +82,8 @@ jobs:
     name: Coverage
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/{{cookiecutter.package_name}}/.github/workflows/codeql.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/codeql.yml
@@ -13,8 +13,11 @@ permissions: {}
 jobs:
   analyze:
     name: Analyze
+    if: ${{ "{{" }} github.event.repository.private == false || vars.CODE_SECURITY_ENABLED == 'true' {{ "}}" }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/{{cookiecutter.package_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     name: Build
+    if: ${{ "{{" }} vars.DOCS_DEPLOYMENT_ENABLED == 'true' {{ "}}" }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/{{cookiecutter.package_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/{{cookiecutter.package_name}}/.github/workflows/zizmor.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/zizmor.yml
@@ -22,6 +22,8 @@ jobs:
     name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,4 +33,5 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
         with:
+          advanced-security: ${{ "{{" }} github.event.repository.private == false || vars.CODE_SECURITY_ENABLED == 'true' {{ "}}" }}
           inputs: ./.github/

--- a/{{cookiecutter.package_name}}/CHANGELOG/{{ cookiecutter.first_version }}.md
+++ b/{{cookiecutter.package_name}}/CHANGELOG/{{ cookiecutter.first_version }}.md
@@ -14,7 +14,7 @@ uv add {{ cookiecutter.package_name }}
 - Tests with pytest, coverage across Python 3.12/3.13/3.14
 - CI via GitHub Actions: lint (Ruff), type check (ty), test matrix, coverage reporting
 - Security scanning: CodeQL analysis, Dependabot, zizmor workflow audit
-- Docs site with Zensical + mkdocstrings, auto-deployed to GitHub Pages
+- Docs site with Zensical + mkdocstrings and a GitHub Pages deployment workflow
 - Trusted publishing to PyPI with OIDC and build provenance attestation
 - `justfile` with dev commands: qa, test, type-check, docs-serve, release
 - Issue templates, PR template, contributing guide, code of conduct, security policy

--- a/{{cookiecutter.package_name}}/CHANGELOG/{{ cookiecutter.first_version }}.md
+++ b/{{cookiecutter.package_name}}/CHANGELOG/{{ cookiecutter.first_version }}.md
@@ -13,7 +13,7 @@ uv add {{ cookiecutter.package_name }}
 - `src/{{ cookiecutter.import_name }}/` package with CLI (Typer + Rich), py.typed marker
 - Tests with pytest, coverage across Python 3.12/3.13/3.14
 - CI via GitHub Actions: lint (Ruff), type check (ty), test matrix, coverage reporting
-- Security scanning: CodeQL analysis, Dependabot, zizmor workflow audit
+- Security scanning: CodeQL analysis for public repositories, Dependabot, and a zizmor workflow audit
 - Docs site with Zensical + mkdocstrings and a GitHub Pages deployment workflow
 - Trusted publishing to PyPI with OIDC and build provenance attestation
 - `justfile` with dev commands: qa, test, type-check, docs-serve, release

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -22,7 +22,11 @@ Documentation is built with [Zensical](https://zensical.org/) and deployed to Gi
 
 API documentation is auto-generated from docstrings using [mkdocstrings](https://mkdocstrings.github.io/).
 
-Docs deploy automatically on push to `main` via GitHub Actions. To enable this, go to your repo's Settings > Pages and set the source to **GitHub Actions**.
+Docs deploy automatically on push to `main` after GitHub Pages is enabled. If
+the generator did not enable it, review the visibility implications first:
+[Pages sites can be public even when their repositories are private](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site),
+and the feature may require a paid GitHub plan for private repositories. Then
+go to Settings > Pages and set the source to **GitHub Actions**.
 
 ## Development
 

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -26,7 +26,16 @@ Docs deploy automatically on push to `main` after GitHub Pages is enabled. If
 the generator did not enable it, review the visibility implications first:
 [Pages sites can be public even when their repositories are private](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site),
 and the feature may require a paid GitHub plan for private repositories. Then
-go to Settings > Pages and set the source to **GitHub Actions**.
+go to Settings > Pages, set the source to **GitHub Actions**, and enable the
+deployment workflow:
+
+```bash
+gh variable set DOCS_DEPLOYMENT_ENABLED \
+    --repo {{ cookiecutter.github_repo_owner }}/{{ cookiecutter.package_name }} \
+    --body true
+```
+
+Until then, deployment stays paused and local preview and builds still work.
 
 ## Development
 

--- a/{{cookiecutter.package_name}}/SECURITY.md
+++ b/{{cookiecutter.package_name}}/SECURITY.md
@@ -14,7 +14,7 @@ Please include:
 
 This project ships with security hardening out of the box:
 
-- **CodeQL** scans code for injection, SSRF, path traversal, and other dataflow vulnerabilities using the `security-extended` query suite
+- **CodeQL** scans public repositories for injection, SSRF, path traversal, and other dataflow vulnerabilities using the `security-extended` query suite. Private repositories can opt in after enabling GitHub Code Security.
 - **Zizmor** audits GitHub Actions workflows for excessive permissions, unpinned actions, credential exposure, and cache poisoning risks
 - **Dependabot** keeps GitHub Actions pinned by SHA and opens PRs for updates, with a 7-day cooldown to avoid adopting compromised releases immediately
 - **All actions pinned by SHA** with version comments, not floating tags

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "{{cookiecutter.package_name}}"
 version = "{{ cookiecutter.first_version }}"
-description = "{{ cookiecutter.project_short_description | replace('\\', '\\\\') | replace('\"', '\\\"') }}"
+description = {{ cookiecutter.project_short_description | tojson }}
 readme = "README.md"
 authors = [
   {name = "{{ cookiecutter.full_name | replace('\\', '\\\\') | replace('\"', '\\\"') }}", email = "{{cookiecutter.email}}"}

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -96,6 +96,9 @@ exclude_also = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/{{ cookiecutter.import_name }}"]
+
 [tool.uv]
 package = true
 default-groups = ["dev"]


### PR DESCRIPTION
## Summary

This PR makes GitHub setup opt-in and hardens generated-project setup.

- Adds `--github ask|skip|private|public`.
- Default generation creates project files only: no Git commit, GitHub repository, remote, Pages site, or `pypi` environment.
- Interactive setup defaults new repositories to private and shows a complete plan before final confirmation.
- Non-interactive setup requires explicit `--github private` or `--github public`; those modes print the plan, with the selected mode serving as consent.
- Existing nonempty repositories are never modified. An existing empty repository can be connected only after separate interactive confirmation; automation stops for manual review.
- Requested setup failures exit nonzero, while the package CLI preserves the generated directory for recovery.
- GitHub CLI operations are pinned to `github.com`, and the first push uses the configured SSH or HTTPS transport.
- Confirmed HTTPS setup configures Git to use the authenticated GitHub CLI credential helper before any repository or Git state is created.

## Generated-project updates

- Pages remains a separate decision: public repositories default on; private repositories warn and default off.
- Documentation deployment is paused until `DOCS_DEPLOYMENT_ENABLED=true`.
- Checkout-dependent CI and publish jobs now declare explicit least-privilege permissions; CodeQL and zizmor retain the permissions required for security reporting.
- CodeQL is skipped for private repositories unless `CODE_SECURITY_ENABLED=true`; zizmor continues to audit workflows without Advanced Security upload when that setting is absent.
- Hatchling explicitly packages `src/{{ cookiecutter.import_name }}`, supporting custom import names that differ from distribution names.
- Pre- and post-generation hooks safely embed descriptions, repository owners, package names, import names, and versions containing quotes, backslashes, or newlines.

## Documentation and validation

Documentation covers optional GitHub setup, automation modes, Pages implications, enabling docs later, PyPI environment recovery, and failure handling. The PR establishes `CHANGELOG/unreleased.md` for work that has not yet been released.

Validated with `just ci` (55 tests plus formatting, linting, import checks, and type checking), `just testall` on Python 3.12–3.14, docs and wheel builds, installed-wheel and local-generation smoke tests, and a live private-repository smoke test. PR checks are green.

The package version remains `0.5.0`; `CHANGELOG/unreleased.md` will be finalized as versioned release notes during release preparation.