### PR TITLE
Finalize changelog notes during release

### DIFF
--- a/CHANGELOG/unreleased.md
+++ b/CHANGELOG/unreleased.md
@@ -54,9 +54,9 @@ These changes affect future generation commands and custom contexts only. Projec
 
 - **See every template variable before generating.** Run `uvx cookiecutter-pypackage --list-variables` to inspect the current variables and their defaults—particularly useful when building scripts or non-interactive workflows. Thanks [@iamamystery](https://github.com/iamamystery)! ([#931](https://github.com/audreyfeldroy/cookiecutter-pypackage/pull/931))
 
-- **A meaningful first changelog entry.** Every generated project starts with
-  `CHANGELOG/<first_version>.md`, describing the scaffold it received and
-  providing a useful starting point for its first GitHub Release.
+- **A working changelog for generated projects.** New projects start with
+  `CHANGELOG/unreleased.md`; `just release` finalizes those notes into the
+  versioned file before tagging the release.
 
 ### What's better
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,19 +104,21 @@ Before you submit a pull request, check that it meets these guidelines:
 
 ## Releasing
 
-1. Bump the version:
+1. Record release-worthy changes in `CHANGELOG/unreleased.md` as they merge.
+2. Bump the version:
 
    ```sh
    uv version --bump patch  # or minor, major
    ```
 
-2. Commit the version bump.
-3. Release:
+3. Commit the version bump.
+4. Release:
 
    ```sh
    just release
    ```
 
-   This creates an annotated `v*` tag, pushes it to GitHub, and creates a
-   GitHub Release with the changelog contents as release notes. The tag
-   push triggers a GitHub Action that builds and publishes to PyPI.
+   This finalizes `CHANGELOG/unreleased.md` as the versioned release notes,
+   creates a fresh unreleased file, commits and pushes that notes commit, then
+   creates an annotated `v*` tag and GitHub Release. The tag push triggers a
+   GitHub Action that builds and publishes to PyPI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ the site. Preview locally with `just docs-serve`.
 
 **A clean project structure.** [src layout](project_structure.md) so you never accidentally import local code during testing. A [py.typed](https://peps.python.org/pep-0561/) marker and type hints on all starter code. `__main__.py` so your package works with `python -m`. A focused .gitignore instead of the 200-line GitHub default.
 
-**Justfile commands for everything.** `just qa` is the daily driver, but there's also `just test`, `just testall`, `just type-check-watch`, `just coverage`, `just docs-serve`, `just tag`, and more. Run `just list` to see them all. See [Project Structure](project_structure.md#justfile-commands) for the full table.
+**Justfile commands for everything.** `just qa` is the daily driver, but there's also `just test`, `just testall`, `just type-check-watch`, `just coverage`, `just docs-serve`, `just release`, and more. Run `just list` to see them all. See [Project Structure](project_structure.md#justfile-commands) for the full table.
 
 **Your name on it.** The generated README includes a bold "Created by" line linking to your GitHub profile, PyPI profile, and personal website. You built the package, you should get the credit.
 

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -32,10 +32,12 @@ my-package/
 ├── tests/
 │   └── test_my_package.py
 ├── scripts/
-│   └── release.py          # Version bump, tag, and push
+│   └── release.py          # Finalize notes, tag, and push
 ├── .editorconfig
 ├── .gitignore
-├── CHANGELOG/              # One file per release (e.g. 0.1.0.md)
+├── CHANGELOG/
+│   ├── unreleased.md        # Work-in-progress release notes
+│   └── X.Y.Z.md             # Immutable notes for each published release
 ├── CODE_OF_CONDUCT.md
 ├── CONTRIBUTING.md
 ├── justfile                # Task runner commands
@@ -78,7 +80,7 @@ Run `just list` to see all available commands. The key ones:
 | `just docs-serve` | Preview docs locally at http://localhost:8000 |
 | `just docs-build` | Build docs |
 | `just coverage` | Run tests with coverage and generate HTML report |
-| `just release` | Tag the current version and push to GitHub |
+| `just release` | Finalize notes, tag the current version, and push to GitHub |
 | `just build` | Build sdist and wheel |
 
 ## GitHub Actions workflows

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -32,7 +32,7 @@ my-package/
 ├── tests/
 │   └── test_my_package.py
 ├── scripts/
-│   └── release.py          # Finalize notes, tag, and push
+│   └── release.py          # Version bump, finalize notes, tag, and push
 ├── .editorconfig
 ├── .gitignore
 ├── CHANGELOG/

--- a/docs/pypi_release_checklist.md
+++ b/docs/pypi_release_checklist.md
@@ -20,16 +20,14 @@
 
 5. Run `just release` to trigger the publish (see below).
 
+## During Development
+
+Record user-visible changes in `CHANGELOG/unreleased.md` as they merge to
+`main`. Keep versioned changelog files reserved for releases.
+
 ## Every Release
 
-1. Write your release notes in `CHANGELOG/X.Y.Z.md` and commit:
-
-    ```bash
-    git add CHANGELOG/
-    git commit -m "Add release notes for vX.Y.Z"
-    ```
-
-2. Bump the version and commit:
+1. Bump the version and commit it:
 
     ```bash
     uv version patch  # or: minor, major
@@ -37,14 +35,27 @@
     git commit -m "Bump version to X.Y.Z"
     ```
 
-3. Push, then tag and push the tag:
+2. Run the release command:
 
     ```bash
-    git push
-    just tag
+    just release
     ```
 
-4. GitHub Actions builds, signs with Sigstore, and publishes to PyPI automatically.
+   `just release` moves `CHANGELOG/unreleased.md` to
+   `CHANGELOG/X.Y.Z.md`, creates a fresh unreleased file, commits and pushes
+   that release-notes commit, then creates and pushes the `vX.Y.Z` tag.
+
+3. GitHub Actions builds, signs with Sigstore, and publishes to PyPI
+   automatically.
+
+Older generated projects that already contain only
+`CHANGELOG/X.Y.Z.md` remain compatible with `just release`.
+
+## Release Recovery
+
+If release preparation fails before the tag is created, inspect the working
+tree and finish or revert the release-notes commit before retrying. Never reuse
+or overwrite an existing tag.
 
 ## Troubleshooting
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,7 +19,7 @@ gh variable set DOCS_DEPLOYMENT_ENABLED --repo OWNER/REPOSITORY --body true
 Push to `main` or go to Actions, find the "Documentation" workflow, and run it
 manually.
 
-## Tag push didn't publish to PyPI
+## Release didn't publish to PyPI
 
 The most common causes:
 
@@ -27,7 +27,12 @@ The most common causes:
 - **`pypi` environment not created.** The post-generation hook attempts this
   only when you opt into GitHub setup. Go to Settings > Environments and create
   an environment named `pypi`.
-- **Tag format wrong.** Tags must match `v*` (e.g., `v0.1.0`). The `just tag` command handles this for you.
+- **Tag format wrong.** Tags must match `v*` (e.g., `v0.1.0`). The `just release` command handles this for you.
+
+If `just release` reports that a tag or GitHub Release already exists, inspect
+the existing tag and release before retrying. The release script can resume a
+failed tag push or GitHub Release creation when the tag still points to the
+current `HEAD`.
 
 If you got the Trusted Publisher configuration wrong, you can delete it on PyPI and create it again.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -195,8 +195,18 @@ Go to that URL, fill in those values, and you're done. This uses OIDC (Trusted P
 
 ## Step 7: Release
 
+As you work, record user-visible changes in `CHANGELOG/unreleased.md`. When
+you are ready to release, bump the version and commit it first:
+
 ```bash
+uv version <version>        # or: uv version --bump minor
+git add pyproject.toml uv.lock
+git commit -m "Bump version to <version>"
+
 just release
 ```
 
-This bumps the version, tags it, pushes, and GitHub Actions builds, signs with Sigstore, and publishes to PyPI automatically. Check the Actions tab to confirm.
+`just release` finalizes the unreleased notes, commits and pushes that notes
+commit, creates the `v<version>` tag and GitHub Release, and then GitHub Actions
+builds, signs with Sigstore, and publishes to PyPI automatically. Check the
+Actions tab to confirm.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -378,11 +378,6 @@ IMPORT_NAME = json.loads(
 {{ cookiecutter.import_name | tojson }}
 """.strip()
 )
-FIRST_VERSION = json.loads(
-    r"""
-{{ cookiecutter.first_version | tojson }}
-""".strip()
-)
 
 COMMIT_MESSAGE = f"""\
 https://github.com/audreyfeldroy/cookiecutter-pypackage scaffolding
@@ -397,7 +392,7 @@ https://github.com/audreyfeldroy/cookiecutter-pypackage scaffolding
 - justfile with development tasks
 - scripts/release.py
 - pyproject.toml with uv build configuration
-- CHANGELOG/{FIRST_VERSION}.md
+- CHANGELOG/unreleased.md
 - LICENSE (MIT)
 - README.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md
 - .editorconfig, .gitignore

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ build:
     rm -rf dist
     uv build
 
-# Tag, push, and create a GitHub release
+# Finalize release notes, tag, push, and create a GitHub release
 release:
     uv run scripts/release.py
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -6,6 +6,7 @@
 import subprocess
 import tomllib
 from pathlib import Path
+from typing import NamedTuple
 
 CHANGELOG_DIR = Path("CHANGELOG")
 UNRELEASED_PATH = CHANGELOG_DIR / "unreleased.md"
@@ -16,6 +17,13 @@ UNRELEASED_TEMPLATE = (
 
 class ReleaseError(RuntimeError):
     """Raised when release preconditions are not satisfied."""
+
+
+class TagState(NamedTuple):
+    """Whether the release tag exists locally and on the remote."""
+
+    local: bool
+    remote: bool
 
 
 def _run(*cmd: str) -> None:
@@ -38,22 +46,55 @@ def _ensure_clean_worktree() -> None:
         raise ReleaseError("Git worktree is not clean; commit or stash changes first.")
 
 
-def _ensure_tag_available(tag: str) -> None:
-    """Reject releases whose tag already exists locally or on origin."""
+def _ensure_tag_state(tag: str) -> TagState:
+    """Validate an existing tag so interrupted releases can be resumed safely."""
     local = _command_result(
-        "git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"
+        "git", "show-ref", "--verify", "--quiet", f"refs/tags/{tag}"
     )
-    if local.returncode == 0:
-        raise ReleaseError(f"Git tag {tag} already exists locally.")
+    if local.returncode not in {0, 1}:
+        error = (local.stderr or local.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not check local tag {tag}: {error}")
+    local_exists = local.returncode == 0
 
     remote = _command_result(
         "git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}"
     )
-    if remote.returncode == 0:
-        raise ReleaseError(f"Git tag {tag} already exists on origin.")
-    if remote.returncode != 2:
+    if remote.returncode not in {0, 2}:
         error = (remote.stderr or remote.stdout).strip() or "unknown error"
         raise ReleaseError(f"Could not check whether {tag} exists on origin: {error}")
+    remote_exists = remote.returncode == 0
+
+    if remote_exists and not local_exists:
+        _run("git", "fetch", "origin", "tag", tag)
+        local = _command_result(
+            "git", "show-ref", "--verify", "--quiet", f"refs/tags/{tag}"
+        )
+        if local.returncode != 0:
+            raise ReleaseError(f"Could not fetch tag {tag} from origin.")
+        local_exists = True
+
+    if local_exists:
+        tag_commit = _command_result(
+            "git", "rev-list", "-n", "1", f"refs/tags/{tag}^" + "{commit}"
+        )
+        head_commit = _command_result("git", "rev-parse", "HEAD")
+        if tag_commit.returncode != 0 or head_commit.returncode != 0:
+            raise ReleaseError(f"Could not verify that tag {tag} points to HEAD.")
+        if tag_commit.stdout.strip() != head_commit.stdout.strip():
+            raise ReleaseError(f"Git tag {tag} does not point to the current HEAD.")
+
+    return TagState(local_exists, remote_exists)
+
+
+def _github_release_exists(tag: str) -> bool:
+    """Return whether GitHub already has a release for the tag."""
+    result = _command_result("gh", "release", "view", tag)
+    if result.returncode == 0:
+        return True
+    error = (result.stderr or result.stdout).strip() or "unknown error"
+    if "not found" in error.lower():
+        return False
+    raise ReleaseError(f"Could not check whether GitHub release {tag} exists: {error}")
 
 
 def _has_release_notes(contents: str) -> bool:
@@ -65,6 +106,15 @@ def _has_release_notes(contents: str) -> bool:
     ]
     template = "\n".join(template_lines).lower()
     return len(lines) > 1 and normalized != template
+
+
+def _is_unreleased_template(contents: str) -> bool:
+    """Return whether unreleased.md is the fresh placeholder created by release."""
+    lines = [line.strip() for line in contents.splitlines() if line.strip()]
+    template_lines = [
+        line.strip() for line in UNRELEASED_TEMPLATE.splitlines() if line.strip()
+    ]
+    return lines == template_lines
 
 
 def _finalized_contents(contents: str, name: str, version: str) -> str:
@@ -81,6 +131,12 @@ def _prepare_release_notes(name: str, version: str) -> Path:
     """Finalize unreleased notes, preserving compatibility with older projects."""
     versioned_path = CHANGELOG_DIR / f"{version}.md"
     if versioned_path.exists() and UNRELEASED_PATH.exists():
+        versioned_contents = versioned_path.read_text(encoding="utf-8")
+        unreleased_contents = UNRELEASED_PATH.read_text(encoding="utf-8")
+        if _has_release_notes(versioned_contents) and _is_unreleased_template(
+            unreleased_contents
+        ):
+            return versioned_path
         raise ReleaseError(
             "Both release changelog files exist; resolve the state manually."
         )
@@ -129,23 +185,27 @@ def main() -> int:
         tag = f"v{version}"
 
         _ensure_clean_worktree()
-        _ensure_tag_available(tag)
+        _ensure_tag_state(tag)
         notes_path = _prepare_release_notes(name, version)
         title, notes = _release_notes(notes_path, name, version)
 
-        _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
-        _run("git", "push", "origin", tag)
-        _run(
-            "gh",
-            "release",
-            "create",
-            tag,
-            "--verify-tag",
-            "--title",
-            title,
-            "--notes",
-            notes,
-        )
+        tag_state = _ensure_tag_state(tag)
+        if not tag_state.local:
+            _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
+        if not tag_state.remote:
+            _run("git", "push", "origin", tag)
+        if not _github_release_exists(tag):
+            _run(
+                "gh",
+                "release",
+                "create",
+                tag,
+                "--verify-tag",
+                "--title",
+                title,
+                "--notes",
+                notes,
+            )
     except ReleaseError as error:
         print(f"Release aborted: {error}")  # noqa: T201
         return 1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,11 +1,21 @@
 # /// script
 # requires-python = ">=3.10"
 # ///
-"""Tag the current version and create a GitHub release."""
+"""Finalize release notes, tag the current version, and create a GitHub release."""
 
 import subprocess
 import tomllib
 from pathlib import Path
+
+CHANGELOG_DIR = Path("CHANGELOG")
+UNRELEASED_PATH = CHANGELOG_DIR / "unreleased.md"
+UNRELEASED_TEMPLATE = (
+    "# Unreleased\n\nRecord user-visible changes here before the next release.\n"
+)
+
+
+class ReleaseError(RuntimeError):
+    """Raised when release preconditions are not satisfied."""
 
 
 def _run(*cmd: str) -> None:
@@ -13,36 +23,137 @@ def _run(*cmd: str) -> None:
     subprocess.run(cmd, check=True)
 
 
-def main() -> None:
-    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
-    name = pyproject["project"]["name"]
-    version = pyproject["project"]["version"]
-    tag = f"v{version}"
-    notes_path = Path(f"CHANGELOG/{version}.md")
+def _command_result(*cmd: str) -> subprocess.CompletedProcess[str]:
+    """Run a read-only command and return its result without raising."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
 
-    lines = notes_path.read_text().splitlines(keepends=True)
+
+def _ensure_clean_worktree() -> None:
+    """Require all release preparation work to be committed already."""
+    result = _command_result("git", "status", "--porcelain")
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not inspect the Git worktree: {error}")
+    if result.stdout.strip():
+        raise ReleaseError("Git worktree is not clean; commit or stash changes first.")
+
+
+def _ensure_tag_available(tag: str) -> None:
+    """Reject releases whose tag already exists locally or on origin."""
+    local = _command_result(
+        "git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"
+    )
+    if local.returncode == 0:
+        raise ReleaseError(f"Git tag {tag} already exists locally.")
+
+    remote = _command_result(
+        "git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}"
+    )
+    if remote.returncode == 0:
+        raise ReleaseError(f"Git tag {tag} already exists on origin.")
+    if remote.returncode != 2:
+        error = (remote.stderr or remote.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not check whether {tag} exists on origin: {error}")
+
+
+def _has_release_notes(contents: str) -> bool:
+    """Return whether unreleased.md contains notes rather than only its template."""
+    lines = [line.strip() for line in contents.splitlines() if line.strip()]
+    normalized = "\n".join(lines).lower()
+    template_lines = [
+        line.strip() for line in UNRELEASED_TEMPLATE.splitlines() if line.strip()
+    ]
+    template = "\n".join(template_lines).lower()
+    return len(lines) > 1 and normalized != template
+
+
+def _finalized_contents(contents: str, name: str, version: str) -> str:
+    """Turn the unreleased heading into a versioned release heading."""
+    lines = contents.splitlines(keepends=True)
+    title = f"# {name} {version}\n"
+    if lines and lines[0].strip().lower() == "# unreleased":
+        lines[0] = title
+        return "".join(lines)
+    return f"{title}\n{contents.lstrip()}"
+
+
+def _prepare_release_notes(name: str, version: str) -> Path:
+    """Finalize unreleased notes, preserving compatibility with older projects."""
+    versioned_path = CHANGELOG_DIR / f"{version}.md"
+    if versioned_path.exists() and UNRELEASED_PATH.exists():
+        raise ReleaseError(
+            "Both release changelog files exist; resolve the state manually."
+        )
+    if versioned_path.exists():
+        if not _has_release_notes(versioned_path.read_text(encoding="utf-8")):
+            raise ReleaseError(f"{versioned_path} does not contain release notes.")
+        return versioned_path
+    if not UNRELEASED_PATH.exists():
+        raise ReleaseError("No release changelog exists; add release notes first.")
+
+    contents = UNRELEASED_PATH.read_text(encoding="utf-8")
+    if not _has_release_notes(contents):
+        raise ReleaseError(f"{UNRELEASED_PATH} does not contain release notes.")
+
+    versioned_path.parent.mkdir(parents=True, exist_ok=True)
+    UNRELEASED_PATH.rename(versioned_path)
+    versioned_path.write_text(
+        _finalized_contents(contents, name, version),
+        encoding="utf-8",
+    )
+    UNRELEASED_PATH.write_text(UNRELEASED_TEMPLATE, encoding="utf-8")
+    _run("git", "add", str(versioned_path), str(UNRELEASED_PATH))
+    _run("git", "commit", "-m", f"Prepare release notes for v{version}")
+    _run("git", "push", "origin", "HEAD")
+    return versioned_path
+
+
+def _release_notes(notes_path: Path, name: str, version: str) -> tuple[str, str]:
+    """Read the GitHub Release title and body from a versioned notes file."""
+    lines = notes_path.read_text(encoding="utf-8").splitlines(keepends=True)
     title = f"{name} {version}"
     if lines and lines[0].startswith("# "):
         title = lines[0].lstrip("# ").strip()
         lines = lines[1:]
         if lines and not lines[0].strip():
             lines = lines[1:]
-    notes = "".join(lines).rstrip()
+    return title, "".join(lines).rstrip()
 
-    _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
-    _run("git", "push", "origin", tag)
-    _run(
-        "gh",
-        "release",
-        "create",
-        tag,
-        "--verify-tag",
-        "--title",
-        title,
-        "--notes",
-        notes,
-    )
+
+def main() -> int:
+    """Run all release preflight checks and publish the release."""
+    try:
+        pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        name = pyproject["project"]["name"]
+        version = pyproject["project"]["version"]
+        tag = f"v{version}"
+
+        _ensure_clean_worktree()
+        _ensure_tag_available(tag)
+        notes_path = _prepare_release_notes(name, version)
+        title, notes = _release_notes(notes_path, name, version)
+
+        _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
+        _run("git", "push", "origin", tag)
+        _run(
+            "gh",
+            "release",
+            "create",
+            tag,
+            "--verify-tag",
+            "--title",
+            title,
+            "--notes",
+            notes,
+        )
+    except ReleaseError as error:
+        print(f"Release aborted: {error}")  # noqa: T201
+        return 1
+    except subprocess.CalledProcessError as error:
+        print(f"Release command failed: {error}")  # noqa: T201
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -28,12 +28,18 @@ class TagState(NamedTuple):
 
 def _run(*cmd: str) -> None:
     print(f"$ {' '.join(cmd)}")  # noqa: T201
-    subprocess.run(cmd, check=True)
+    try:
+        subprocess.run(cmd, check=True)
+    except OSError as error:
+        raise ReleaseError(f"Could not run {' '.join(cmd)}: {error}") from error
 
 
 def _command_result(*cmd: str) -> subprocess.CompletedProcess[str]:
     """Run a read-only command and return its result without raising."""
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except OSError as error:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(error))
 
 
 def _ensure_clean_worktree() -> None:
@@ -57,12 +63,29 @@ def _ensure_tag_state(tag: str) -> TagState:
     local_exists = local.returncode == 0
 
     remote = _command_result(
-        "git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}"
+        "git",
+        "ls-remote",
+        "--exit-code",
+        "--tags",
+        "origin",
+        f"refs/tags/{tag}*",
     )
     if remote.returncode not in {0, 2}:
         error = (remote.stderr or remote.stdout).strip() or "unknown error"
         raise ReleaseError(f"Could not check whether {tag} exists on origin: {error}")
-    remote_exists = remote.returncode == 0
+    remote_lines = [
+        line.split("\t", 1) for line in remote.stdout.splitlines() if "\t" in line
+    ]
+    remote_refs = {ref: commit for commit, ref in remote_lines}
+    remote_tag_ref = f"refs/tags/{tag}"
+    remote_commit = remote_refs.get(remote_tag_ref + "^{}") or remote_refs.get(
+        remote_tag_ref
+    )
+    if remote.returncode == 0 and remote_commit is None:
+        raise ReleaseError(
+            f"Could not determine which commit remote tag {tag} points to."
+        )
+    remote_exists = remote_commit is not None
 
     if remote_exists and not local_exists:
         _run("git", "fetch", "origin", "tag", tag)
@@ -80,7 +103,10 @@ def _ensure_tag_state(tag: str) -> TagState:
         head_commit = _command_result("git", "rev-parse", "HEAD")
         if tag_commit.returncode != 0 or head_commit.returncode != 0:
             raise ReleaseError(f"Could not verify that tag {tag} points to HEAD.")
-        if tag_commit.stdout.strip() != head_commit.stdout.strip():
+        local_commit = tag_commit.stdout.strip()
+        if remote_commit and remote_commit != local_commit:
+            raise ReleaseError(f"Git tag {tag} differs between local and origin.")
+        if local_commit != head_commit.stdout.strip():
             raise ReleaseError(f"Git tag {tag} does not point to the current HEAD.")
 
     return TagState(local_exists, remote_exists)
@@ -136,6 +162,7 @@ def _prepare_release_notes(name: str, version: str) -> Path:
         if _has_release_notes(versioned_contents) and _is_unreleased_template(
             unreleased_contents
         ):
+            _run("git", "push", "origin", "HEAD")
             return versioned_path
         raise ReleaseError(
             "Both release changelog files exist; resolve the state manually."
@@ -210,6 +237,9 @@ def main() -> int:
         print(f"Release aborted: {error}")  # noqa: T201
         return 1
     except subprocess.CalledProcessError as error:
+        print(f"Release command failed: {error}")  # noqa: T201
+        return 1
+    except OSError as error:
         print(f"Release command failed: {error}")  # noqa: T201
         return 1
     return 0

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -10,6 +10,7 @@ from typing import NamedTuple
 
 CHANGELOG_DIR = Path("CHANGELOG")
 UNRELEASED_PATH = CHANGELOG_DIR / "unreleased.md"
+RELEASE_BRANCH = "main"
 UNRELEASED_TEMPLATE = (
     "# Unreleased\n\nRecord user-visible changes here before the next release.\n"
 )
@@ -52,6 +53,43 @@ def _ensure_clean_worktree() -> None:
         raise ReleaseError("Git worktree is not clean; commit or stash changes first.")
 
 
+def _ensure_release_branch() -> None:
+    """Require HEAD to be the current commit on the protected release branch."""
+    branch = _command_result("git", "branch", "--show-current")
+    if branch.returncode != 0:
+        error = (branch.stderr or branch.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not inspect the current Git branch: {error}")
+    if branch.stdout.strip() != RELEASE_BRANCH:
+        raise ReleaseError(f"Releases must run from the {RELEASE_BRANCH} branch.")
+
+    head = _command_result("git", "rev-parse", "HEAD")
+    remote = _command_result(
+        "git", "ls-remote", "--exit-code", "origin", f"refs/heads/{RELEASE_BRANCH}"
+    )
+    if head.returncode != 0 or remote.returncode not in {0, 2}:
+        error = (head.stderr or remote.stderr or head.stdout or remote.stdout).strip()
+        raise ReleaseError(
+            f"Could not verify that {RELEASE_BRANCH} matches origin: {error or 'unknown error'}"
+        )
+    remote_lines = [
+        line.split("\t", 1) for line in remote.stdout.splitlines() if "\t" in line
+    ]
+    remote_refs = {ref: commit for commit, ref in remote_lines}
+    remote_commit = remote_refs.get(f"refs/heads/{RELEASE_BRANCH}")
+    if remote_commit is None:
+        raise ReleaseError(f"origin does not have a {RELEASE_BRANCH} branch.")
+    if head.stdout.strip() != remote_commit:
+        raise ReleaseError(
+            f"{RELEASE_BRANCH} must match origin/{RELEASE_BRANCH} before release."
+        )
+
+
+def _push_release_branch() -> None:
+    """Push prepared release work and re-verify the protected branch."""
+    _run("git", "push", "origin", f"HEAD:{RELEASE_BRANCH}")
+    _ensure_release_branch()
+
+
 def _ensure_tag_state(tag: str) -> TagState:
     """Validate an existing tag so interrupted releases can be resumed safely."""
     local = _command_result(
@@ -68,7 +106,8 @@ def _ensure_tag_state(tag: str) -> TagState:
         "--exit-code",
         "--tags",
         "origin",
-        f"refs/tags/{tag}*",
+        f"refs/tags/{tag}",
+        f"refs/tags/{tag}^" + "{}",
     )
     if remote.returncode not in {0, 2}:
         error = (remote.stderr or remote.stdout).strip() or "unknown error"
@@ -81,10 +120,6 @@ def _ensure_tag_state(tag: str) -> TagState:
     remote_commit = remote_refs.get(remote_tag_ref + "^{}") or remote_refs.get(
         remote_tag_ref
     )
-    if remote.returncode == 0 and remote_commit is None:
-        raise ReleaseError(
-            f"Could not determine which commit remote tag {tag} points to."
-        )
     remote_exists = remote_commit is not None
 
     if remote_exists and not local_exists:
@@ -162,7 +197,6 @@ def _prepare_release_notes(name: str, version: str) -> Path:
         if _has_release_notes(versioned_contents) and _is_unreleased_template(
             unreleased_contents
         ):
-            _run("git", "push", "origin", "HEAD")
             return versioned_path
         raise ReleaseError(
             "Both release changelog files exist; resolve the state manually."
@@ -187,7 +221,6 @@ def _prepare_release_notes(name: str, version: str) -> Path:
     UNRELEASED_PATH.write_text(UNRELEASED_TEMPLATE, encoding="utf-8")
     _run("git", "add", str(versioned_path), str(UNRELEASED_PATH))
     _run("git", "commit", "-m", f"Prepare release notes for v{version}")
-    _run("git", "push", "origin", "HEAD")
     return versioned_path
 
 
@@ -212,8 +245,10 @@ def main() -> int:
         tag = f"v{version}"
 
         _ensure_clean_worktree()
+        _ensure_release_branch()
         _ensure_tag_state(tag)
         notes_path = _prepare_release_notes(name, version)
+        _push_release_branch()
         title, notes = _release_notes(notes_path, name, version)
 
         tag_state = _ensure_tag_state(tag)

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -1,4 +1,5 @@
 import datetime
+import importlib.util
 import json
 import shlex
 import subprocess
@@ -44,6 +45,32 @@ def test_bake_starts_with_an_unreleased_changelog(cookies):
     changelog = result.project_path / "CHANGELOG"
     assert (changelog / "unreleased.md").is_file()
     assert not (changelog / "1.2.3.md").exists()
+
+
+def test_baked_release_script_finalizes_changelog(cookies, monkeypatch):
+    """The rendered release script can finalize notes and prepare a retryable state."""
+    result = cookies.bake()
+    assert result.exit_code == 0
+
+    script_path = result.project_path / "scripts" / "release.py"
+    spec = importlib.util.spec_from_file_location("baked_release_script", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    release = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(release)
+
+    commands = []
+    monkeypatch.chdir(result.project_path)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    notes_path = release._prepare_release_notes("Python Boilerplate", "0.1.0")
+
+    assert notes_path == release.CHANGELOG_DIR / "0.1.0.md"
+    assert notes_path.exists()
+    assert (result.project_path / "CHANGELOG" / "unreleased.md").read_text(
+        encoding="utf-8"
+    ) == release.UNRELEASED_TEMPLATE
+    assert commands[-1] == ("git", "push", "origin", "HEAD")
 
 
 def test_bake_and_run_tests(cookies):

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -47,8 +47,8 @@ def test_bake_starts_with_an_unreleased_changelog(cookies):
     assert not (changelog / "1.2.3.md").exists()
 
 
-def test_baked_release_script_finalizes_changelog(cookies, monkeypatch):
-    """The rendered release script can finalize notes and prepare a retryable state."""
+def test_baked_release_script_runs_the_release_lifecycle(cookies, monkeypatch):
+    """The rendered release script finalizes notes and synchronizes main before tagging."""
     result = cookies.bake()
     assert result.exit_code == 0
 
@@ -61,16 +61,22 @@ def test_baked_release_script_finalizes_changelog(cookies, monkeypatch):
 
     commands = []
     monkeypatch.chdir(result.project_path)
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    monkeypatch.setattr(release, "_ensure_release_branch", lambda: None)
+    monkeypatch.setattr(
+        release, "_ensure_tag_state", lambda tag: release.TagState(False, False)
+    )
+    monkeypatch.setattr(release, "_github_release_exists", lambda tag: False)
     monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
 
-    notes_path = release._prepare_release_notes("Python Boilerplate", "0.1.0")
+    assert release.main() == 0
 
-    assert notes_path == release.CHANGELOG_DIR / "0.1.0.md"
+    notes_path = result.project_path / "CHANGELOG" / "0.1.0.md"
     assert notes_path.exists()
     assert (result.project_path / "CHANGELOG" / "unreleased.md").read_text(
         encoding="utf-8"
     ) == release.UNRELEASED_TEMPLATE
-    assert commands[-1] == ("git", "push", "origin", "HEAD")
+    assert ("git", "push", "origin", "HEAD:main") in commands
 
 
 def test_bake_and_run_tests(cookies):

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -36,6 +36,16 @@ def test_bake_with_defaults(cookies):
     assert "tests" in found_toplevel_files
 
 
+def test_bake_starts_with_an_unreleased_changelog(cookies):
+    """Generated projects keep work-in-progress notes separate from releases."""
+    result = cookies.bake(extra_context={"first_version": "1.2.3"})
+
+    assert result.exit_code == 0
+    changelog = result.project_path / "CHANGELOG"
+    assert (changelog / "unreleased.md").is_file()
+    assert not (changelog / "1.2.3.md").exists()
+
+
 def test_bake_and_run_tests(cookies):
     result = cookies.bake()
     assert result.project_path.is_dir()

--- a/tests/test_post_gen_project.py
+++ b/tests/test_post_gen_project.py
@@ -575,7 +575,6 @@ def test_all_hook_template_values_are_rendered_safely(tmp_path):
         "github_repo_owner": 'owner"\\\nnext',
         "package_name": 'repo"\\\nnext',
         "import_name": 'module"\\\nnext',
-        "first_version": '1.0"\\\nnext',
     }
 
     hook = load_hook(tmp_path, **values)
@@ -583,4 +582,3 @@ def test_all_hook_template_values_are_rendered_safely(tmp_path):
     assert hook.OWNER == values["github_repo_owner"]
     assert hook.REPO == values["package_name"]
     assert hook.IMPORT_NAME == values["import_name"]
-    assert hook.FIRST_VERSION == values["first_version"]

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -50,7 +50,10 @@ def test_unreleased_notes_are_finalized_before_tagging(release, tmp_path, monkey
     )
     commands = []
     monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
-    monkeypatch.setattr(release, "_ensure_tag_available", lambda tag: None)
+    monkeypatch.setattr(
+        release, "_ensure_tag_state", lambda tag: release.TagState(False, False)
+    )
+    monkeypatch.setattr(release, "_github_release_exists", lambda tag: False)
     monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
 
     assert release.main() == 0
@@ -88,6 +91,111 @@ def test_legacy_versioned_notes_are_used_without_a_notes_commit(
         "CHANGELOG/1.2.3.md"
     )
     assert commands == []
+
+
+def test_prepared_changelog_pair_is_retryable(release, tmp_path, monkeypatch):
+    """A notes commit that was not pushed can be resumed without duplication."""
+    write_pyproject(tmp_path)
+    (tmp_path / "CHANGELOG" / "1.2.3.md").write_text(
+        "# example-package 1.2.3\n\n- Existing notes.\n", encoding="utf-8"
+    )
+    (tmp_path / "CHANGELOG" / "unreleased.md").write_text(
+        release.UNRELEASED_TEMPLATE, encoding="utf-8"
+    )
+    commands = []
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release._prepare_release_notes("example-package", "1.2.3") == Path(
+        "CHANGELOG/1.2.3.md"
+    )
+    assert commands == []
+
+
+def test_local_tag_retry_pushes_without_retagging(release, tmp_path, monkeypatch):
+    """A failed tag push can resume from the validated local tag."""
+    write_pyproject(tmp_path)
+    (tmp_path / "CHANGELOG" / "1.2.3.md").write_text(
+        "# example-package 1.2.3\n\n- Existing notes.\n", encoding="utf-8"
+    )
+    commands = []
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    monkeypatch.setattr(
+        release, "_ensure_tag_state", lambda tag: release.TagState(True, False)
+    )
+    monkeypatch.setattr(release, "_github_release_exists", lambda tag: False)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release.main() == 0
+    assert not any(command[:2] == ("git", "tag") for command in commands)
+    assert ("git", "push", "origin", "v1.2.3") in commands
+    assert any(command[:3] == ("gh", "release", "create") for command in commands)
+
+
+def test_existing_github_release_skips_republish(release, tmp_path, monkeypatch):
+    """A retry does not recreate a GitHub Release that already exists."""
+    write_pyproject(tmp_path)
+    (tmp_path / "CHANGELOG" / "1.2.3.md").write_text(
+        "# example-package 1.2.3\n\n- Existing notes.\n", encoding="utf-8"
+    )
+    commands = []
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    monkeypatch.setattr(
+        release, "_ensure_tag_state", lambda tag: release.TagState(True, True)
+    )
+    monkeypatch.setattr(release, "_github_release_exists", lambda tag: True)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release.main() == 0
+    assert commands == []
+
+
+def test_remote_tag_is_fetched_and_verified(release, monkeypatch):
+    """A remote-only tag is fetched before the release is resumed."""
+    commands = []
+    show_ref_calls = 0
+
+    def fake_command_result(*command):
+        nonlocal show_ref_calls
+        if command[:2] == ("git", "show-ref"):
+            show_ref_calls += 1
+            return release.subprocess.CompletedProcess(
+                command, 1 if show_ref_calls == 1 else 0
+            )
+        if command[:3] == ("git", "ls-remote", "--exit-code"):
+            return release.subprocess.CompletedProcess(command, 0)
+        if command[:2] == ("git", "rev-list"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="same\n")
+        if command[:2] == ("git", "rev-parse"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="same\n")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(release, "_command_result", fake_command_result)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release._ensure_tag_state("v1.2.3") == release.TagState(True, True)
+    assert commands == [("git", "fetch", "origin", "tag", "v1.2.3")]
+
+
+def test_tag_on_another_commit_is_rejected(release, monkeypatch):
+    """A tag pointing elsewhere cannot be reused for the current release."""
+
+    def fake_command_result(*command):
+        if command[:2] == ("git", "show-ref"):
+            return release.subprocess.CompletedProcess(command, 0)
+        if command[:3] == ("git", "ls-remote", "--exit-code"):
+            return release.subprocess.CompletedProcess(command, 0)
+        if command[:2] == ("git", "rev-list"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="tag\n")
+        if command[:2] == ("git", "rev-parse"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="head\n")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(release, "_command_result", fake_command_result)
+
+    with pytest.raises(
+        release.ReleaseError, match="does not point to the current HEAD"
+    ):
+        release._ensure_tag_state("v1.2.3")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,166 @@
+"""Tests for the release script's changelog lifecycle."""
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "release.py"
+TEMPLATE_SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "{{cookiecutter.package_name}}"
+    / "scripts"
+    / "release.py"
+)
+
+
+def load_release_script():
+    """Load the outer release script without executing its CLI entry point."""
+    spec = importlib.util.spec_from_file_location("release_script", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def release(tmp_path, monkeypatch):
+    """Load the release script in an isolated project directory."""
+    (tmp_path / "CHANGELOG").mkdir()
+    monkeypatch.chdir(tmp_path)
+    return load_release_script()
+
+
+def write_pyproject(tmp_path, *, name="example-package", version="1.2.3"):
+    """Write the minimal project metadata read by the release script."""
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def test_unreleased_notes_are_finalized_before_tagging(release, tmp_path, monkeypatch):
+    """A release notes commit is pushed before the release tag is created."""
+    write_pyproject(tmp_path)
+    (tmp_path / "CHANGELOG" / "unreleased.md").write_text(
+        "# Unreleased\n\n## Added\n\n- A feature.\n",
+        encoding="utf-8",
+    )
+    commands = []
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    monkeypatch.setattr(release, "_ensure_tag_available", lambda tag: None)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release.main() == 0
+
+    changelog = tmp_path / "CHANGELOG"
+    assert (
+        (changelog / "1.2.3.md")
+        .read_text(encoding="utf-8")
+        .startswith("# example-package 1.2.3\n")
+    )
+    assert (changelog / "unreleased.md").read_text(encoding="utf-8") == (
+        release.UNRELEASED_TEMPLATE
+    )
+    commit_index = commands.index(
+        ("git", "commit", "-m", "Prepare release notes for v1.2.3")
+    )
+    tag_index = commands.index(("git", "tag", "-a", "v1.2.3", "-m", "Release v1.2.3"))
+    assert commit_index < tag_index
+    assert commands[commit_index + 1] == ("git", "push", "origin", "HEAD")
+
+
+def test_legacy_versioned_notes_are_used_without_a_notes_commit(
+    release, tmp_path, monkeypatch
+):
+    """Older generated projects with versioned notes remain supported."""
+    write_pyproject(tmp_path)
+    notes_path = tmp_path / "CHANGELOG" / "1.2.3.md"
+    notes_path.write_text(
+        "# example-package 1.2.3\n\n- Existing notes.\n", encoding="utf-8"
+    )
+    commands = []
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release._prepare_release_notes("example-package", "1.2.3") == Path(
+        "CHANGELOG/1.2.3.md"
+    )
+    assert commands == []
+
+
+@pytest.mark.parametrize(
+    ("versioned", "unreleased"),
+    [(True, True), (False, False)],
+)
+def test_invalid_changelog_states_abort_before_writing(
+    release, tmp_path, monkeypatch, versioned, unreleased
+):
+    """Ambiguous or missing release notes fail without invoking Git."""
+    write_pyproject(tmp_path)
+    changelog = tmp_path / "CHANGELOG"
+    if versioned:
+        (changelog / "1.2.3.md").write_text("# Existing\n", encoding="utf-8")
+    if unreleased:
+        (changelog / "unreleased.md").write_text(
+            "# Unreleased\n\n- Draft notes.\n", encoding="utf-8"
+        )
+    commands = []
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+    with pytest.raises(release.ReleaseError):
+        release._prepare_release_notes("example-package", "1.2.3")
+    assert commands == []
+
+
+def test_empty_unreleased_notes_abort_before_writing(release, tmp_path, monkeypatch):
+    """A placeholder changelog cannot accidentally create an empty release."""
+    write_pyproject(tmp_path)
+    changelog = tmp_path / "CHANGELOG"
+    (changelog / "unreleased.md").write_text(
+        release.UNRELEASED_TEMPLATE, encoding="utf-8"
+    )
+    commands = []
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    with pytest.raises(release.ReleaseError):
+        release._prepare_release_notes("example-package", "1.2.3")
+    assert commands == []
+
+
+def test_empty_legacy_notes_abort_before_writing(release, tmp_path, monkeypatch):
+    """A legacy versioned file must still contain actual release notes."""
+    write_pyproject(tmp_path)
+    (tmp_path / "CHANGELOG" / "1.2.3.md").write_text(
+        "# example-package 1.2.3\n", encoding="utf-8"
+    )
+    commands = []
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    with pytest.raises(release.ReleaseError):
+        release._prepare_release_notes("example-package", "1.2.3")
+    assert commands == []
+
+
+def test_dirty_worktree_aborts_before_release_commands(release, monkeypatch):
+    """A dirty worktree stops the release before any write command runs."""
+    commands = []
+    monkeypatch.setattr(
+        release,
+        "_command_result",
+        lambda *command: release.subprocess.CompletedProcess(
+            command, 0, stdout=" M pyproject.toml\n", stderr=""
+        ),
+    )
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    with pytest.raises(release.ReleaseError):
+        release._ensure_clean_worktree()
+    assert commands == []
+
+
+def test_outer_and_generated_release_scripts_stay_functionally_aligned():
+    """The generated release workflow must match the outer workflow's behavior."""
+    outer_tree = ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
+    template_tree = ast.parse(TEMPLATE_SCRIPT_PATH.read_text(encoding="utf-8"))
+    assert ast.dump(outer_tree) == ast.dump(template_tree)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -41,6 +41,11 @@ def write_pyproject(tmp_path, *, name="example-package", version="1.2.3"):
     )
 
 
+def allow_release_branch(monkeypatch, release):
+    """Skip branch verification when a test targets a later release stage."""
+    monkeypatch.setattr(release, "_ensure_release_branch", lambda: None)
+
+
 def test_unreleased_notes_are_finalized_before_tagging(release, tmp_path, monkeypatch):
     """A release notes commit is pushed before the release tag is created."""
     write_pyproject(tmp_path)
@@ -50,6 +55,7 @@ def test_unreleased_notes_are_finalized_before_tagging(release, tmp_path, monkey
     )
     commands = []
     monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    allow_release_branch(monkeypatch, release)
     monkeypatch.setattr(
         release, "_ensure_tag_state", lambda tag: release.TagState(False, False)
     )
@@ -72,7 +78,7 @@ def test_unreleased_notes_are_finalized_before_tagging(release, tmp_path, monkey
     )
     tag_index = commands.index(("git", "tag", "-a", "v1.2.3", "-m", "Release v1.2.3"))
     assert commit_index < tag_index
-    assert commands[commit_index + 1] == ("git", "push", "origin", "HEAD")
+    assert commands[commit_index + 1] == ("git", "push", "origin", "HEAD:main")
 
 
 def test_legacy_versioned_notes_are_used_without_a_notes_commit(
@@ -104,12 +110,18 @@ def test_notes_push_failure_leaves_retryable_state(release, tmp_path, monkeypatc
 
     def fail_push(*command):
         commands.append(command)
-        if command == ("git", "push", "origin", "HEAD"):
+        if command == ("git", "push", "origin", "HEAD:main"):
             raise release.subprocess.CalledProcessError(1, command)
 
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    allow_release_branch(monkeypatch, release)
+    monkeypatch.setattr(
+        release, "_ensure_tag_state", lambda tag: release.TagState(False, False)
+    )
+    monkeypatch.setattr(release, "_github_release_exists", lambda tag: False)
     monkeypatch.setattr(release, "_run", fail_push)
-    with pytest.raises(release.subprocess.CalledProcessError):
-        release._prepare_release_notes("example-package", "1.2.3")
+
+    assert release.main() == 1
 
     assert (tmp_path / "CHANGELOG" / "1.2.3.md").exists()
     assert unreleased.read_text(encoding="utf-8") == release.UNRELEASED_TEMPLATE
@@ -118,8 +130,9 @@ def test_notes_push_failure_leaves_retryable_state(release, tmp_path, monkeypatc
     monkeypatch.setattr(
         release, "_run", lambda *command: retry_commands.append(command)
     )
-    release._prepare_release_notes("example-package", "1.2.3")
-    assert retry_commands == [("git", "push", "origin", "HEAD")]
+    assert release.main() == 0
+    assert retry_commands[0] == ("git", "push", "origin", "HEAD:main")
+    assert not any(command[:2] == ("git", "commit") for command in retry_commands)
 
 
 def test_prepared_changelog_pair_is_retryable(release, tmp_path, monkeypatch):
@@ -137,7 +150,7 @@ def test_prepared_changelog_pair_is_retryable(release, tmp_path, monkeypatch):
     assert release._prepare_release_notes("example-package", "1.2.3") == Path(
         "CHANGELOG/1.2.3.md"
     )
-    assert commands == [("git", "push", "origin", "HEAD")]
+    assert commands == []
 
 
 def test_local_tag_retry_pushes_without_retagging(release, tmp_path, monkeypatch):
@@ -148,6 +161,7 @@ def test_local_tag_retry_pushes_without_retagging(release, tmp_path, monkeypatch
     )
     commands = []
     monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    allow_release_branch(monkeypatch, release)
     monkeypatch.setattr(
         release, "_ensure_tag_state", lambda tag: release.TagState(True, False)
     )
@@ -155,6 +169,7 @@ def test_local_tag_retry_pushes_without_retagging(release, tmp_path, monkeypatch
     monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
 
     assert release.main() == 0
+    assert ("git", "push", "origin", "HEAD:main") in commands
     assert not any(command[:2] == ("git", "tag") for command in commands)
     assert ("git", "push", "origin", "v1.2.3") in commands
     assert any(command[:3] == ("gh", "release", "create") for command in commands)
@@ -168,6 +183,7 @@ def test_existing_github_release_skips_republish(release, tmp_path, monkeypatch)
     )
     commands = []
     monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    allow_release_branch(monkeypatch, release)
     monkeypatch.setattr(
         release, "_ensure_tag_state", lambda tag: release.TagState(True, True)
     )
@@ -175,7 +191,29 @@ def test_existing_github_release_skips_republish(release, tmp_path, monkeypatch)
     monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
 
     assert release.main() == 0
-    assert commands == []
+    assert commands == [("git", "push", "origin", "HEAD:main")]
+
+
+def test_legacy_notes_push_main_before_tagging(release, tmp_path, monkeypatch):
+    """Legacy notes still synchronize main before creating the release tag."""
+    write_pyproject(tmp_path)
+    (tmp_path / "CHANGELOG" / "1.2.3.md").write_text(
+        "# example-package 1.2.3\n\n- Existing notes.\n", encoding="utf-8"
+    )
+    commands = []
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    allow_release_branch(monkeypatch, release)
+    monkeypatch.setattr(
+        release, "_ensure_tag_state", lambda tag: release.TagState(False, False)
+    )
+    monkeypatch.setattr(release, "_github_release_exists", lambda tag: False)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release.main() == 0
+
+    assert commands.index(("git", "push", "origin", "HEAD:main")) < commands.index(
+        ("git", "tag", "-a", "v1.2.3", "-m", "Release v1.2.3")
+    )
 
 
 @pytest.mark.parametrize(
@@ -211,6 +249,7 @@ def test_publish_failures_abort_without_reporting_success(
         "published_tag": release.TagState(True, True),
     }
     monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    allow_release_branch(monkeypatch, release)
     monkeypatch.setattr(release, "_ensure_tag_state", lambda tag: states[tag_state])
     monkeypatch.setattr(release, "_github_release_exists", lambda tag: False)
 
@@ -241,6 +280,8 @@ def test_main_reports_unexpected_os_error(release, tmp_path, monkeypatch):
     """The CLI converts unexpected executable errors into a failed result."""
     write_pyproject(tmp_path)
     monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    allow_release_branch(monkeypatch, release)
+    monkeypatch.setattr(release, "_push_release_branch", lambda: None)
     monkeypatch.setattr(
         release, "_ensure_tag_state", lambda tag: release.TagState(True, True)
     )
@@ -257,6 +298,52 @@ def test_main_reports_unexpected_os_error(release, tmp_path, monkeypatch):
     )
 
     assert release.main() == 1
+
+
+def test_non_main_branch_aborts_before_release_mutation(release, tmp_path, monkeypatch):
+    """A release cannot publish a feature branch by accident."""
+    write_pyproject(tmp_path)
+    unreleased = tmp_path / "CHANGELOG" / "unreleased.md"
+    unreleased.write_text("# Unreleased\n\n- A feature.\n", encoding="utf-8")
+    commands = []
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+
+    def fake_command_result(*command):
+        if command == ("git", "branch", "--show-current"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="feature\n")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(release, "_command_result", fake_command_result)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release.main() == 1
+    assert commands == []
+    assert unreleased.exists()
+    assert not (tmp_path / "CHANGELOG" / "1.2.3.md").exists()
+
+
+def test_diverged_main_aborts_before_release_mutation(release, tmp_path, monkeypatch):
+    """A local main that differs from origin/main cannot be released."""
+    write_pyproject(tmp_path)
+    commands = []
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+
+    def fake_command_result(*command):
+        if command == ("git", "branch", "--show-current"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="main\n")
+        if command == ("git", "rev-parse", "HEAD"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="local\n")
+        if command[:2] == ("git", "ls-remote"):
+            return release.subprocess.CompletedProcess(
+                command, 0, stdout="remote\trefs/heads/main\n"
+            )
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(release, "_command_result", fake_command_result)
+    monkeypatch.setattr(release, "_run", lambda *command: commands.append(command))
+
+    assert release.main() == 1
+    assert commands == []
 
 
 def test_remote_tag_is_fetched_and_verified(release, monkeypatch):
@@ -286,6 +373,24 @@ def test_remote_tag_is_fetched_and_verified(release, monkeypatch):
 
     assert release._ensure_tag_state("v1.2.3") == release.TagState(True, True)
     assert commands == [("git", "fetch", "origin", "tag", "v1.2.3")]
+
+
+def test_pre_release_tag_does_not_block_a_new_final_tag(release, monkeypatch):
+    """Only exact remote tag refs affect the current release tag state."""
+
+    def fake_command_result(*command):
+        if command[:2] == ("git", "show-ref"):
+            return release.subprocess.CompletedProcess(command, 1)
+        if command[:3] == ("git", "ls-remote", "--exit-code"):
+            assert command[-2:] == ("refs/tags/v1.2.3", "refs/tags/v1.2.3^{}")
+            return release.subprocess.CompletedProcess(
+                command, 0, stdout="pre-release\trefs/tags/v1.2.3rc1\n"
+            )
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(release, "_command_result", fake_command_result)
+
+    assert release._ensure_tag_state("v1.2.3") == release.TagState(False, False)
 
 
 def test_tag_on_another_commit_is_rejected(release, monkeypatch):

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -93,6 +93,35 @@ def test_legacy_versioned_notes_are_used_without_a_notes_commit(
     assert commands == []
 
 
+def test_notes_push_failure_leaves_retryable_state(release, tmp_path, monkeypatch):
+    """A failed notes push can be retried without recreating the commit."""
+    write_pyproject(tmp_path)
+    unreleased = tmp_path / "CHANGELOG" / "unreleased.md"
+    unreleased.write_text(
+        "# Unreleased\n\n## Added\n\n- A feature.\n", encoding="utf-8"
+    )
+    commands = []
+
+    def fail_push(*command):
+        commands.append(command)
+        if command == ("git", "push", "origin", "HEAD"):
+            raise release.subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(release, "_run", fail_push)
+    with pytest.raises(release.subprocess.CalledProcessError):
+        release._prepare_release_notes("example-package", "1.2.3")
+
+    assert (tmp_path / "CHANGELOG" / "1.2.3.md").exists()
+    assert unreleased.read_text(encoding="utf-8") == release.UNRELEASED_TEMPLATE
+
+    retry_commands = []
+    monkeypatch.setattr(
+        release, "_run", lambda *command: retry_commands.append(command)
+    )
+    release._prepare_release_notes("example-package", "1.2.3")
+    assert retry_commands == [("git", "push", "origin", "HEAD")]
+
+
 def test_prepared_changelog_pair_is_retryable(release, tmp_path, monkeypatch):
     """A notes commit that was not pushed can be resumed without duplication."""
     write_pyproject(tmp_path)
@@ -108,7 +137,7 @@ def test_prepared_changelog_pair_is_retryable(release, tmp_path, monkeypatch):
     assert release._prepare_release_notes("example-package", "1.2.3") == Path(
         "CHANGELOG/1.2.3.md"
     )
-    assert commands == []
+    assert commands == [("git", "push", "origin", "HEAD")]
 
 
 def test_local_tag_retry_pushes_without_retagging(release, tmp_path, monkeypatch):
@@ -149,6 +178,87 @@ def test_existing_github_release_skips_republish(release, tmp_path, monkeypatch)
     assert commands == []
 
 
+@pytest.mark.parametrize(
+    ("tag_state", "failed_command"),
+    [
+        ("local_only", ("git", "push", "origin", "v1.2.3")),
+        (
+            "published_tag",
+            (
+                "gh",
+                "release",
+                "create",
+                "v1.2.3",
+                "--verify-tag",
+                "--title",
+                "Release",
+                "--notes",
+                "Notes",
+            ),
+        ),
+    ],
+)
+def test_publish_failures_abort_without_reporting_success(
+    release, tmp_path, monkeypatch, tag_state, failed_command
+):
+    """Tag and GitHub publish failures return a failed release result."""
+    write_pyproject(tmp_path)
+    (tmp_path / "CHANGELOG" / "1.2.3.md").write_text(
+        "# Release\n\nNotes\n", encoding="utf-8"
+    )
+    states = {
+        "local_only": release.TagState(True, False),
+        "published_tag": release.TagState(True, True),
+    }
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    monkeypatch.setattr(release, "_ensure_tag_state", lambda tag: states[tag_state])
+    monkeypatch.setattr(release, "_github_release_exists", lambda tag: False)
+
+    def fail_command(*command):
+        if command == failed_command:
+            raise release.subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(release, "_run", fail_command)
+
+    assert release.main() == 1
+
+
+def test_github_release_lookup_failure_is_reported(release, monkeypatch):
+    """Unexpected GitHub lookup errors do not look like a missing release."""
+    monkeypatch.setattr(
+        release,
+        "_command_result",
+        lambda *command: release.subprocess.CompletedProcess(
+            command, 1, stdout="", stderr="permission denied"
+        ),
+    )
+
+    with pytest.raises(release.ReleaseError, match="permission denied"):
+        release._github_release_exists("v1.2.3")
+
+
+def test_main_reports_unexpected_os_error(release, tmp_path, monkeypatch):
+    """The CLI converts unexpected executable errors into a failed result."""
+    write_pyproject(tmp_path)
+    monkeypatch.setattr(release, "_ensure_clean_worktree", lambda: None)
+    monkeypatch.setattr(
+        release, "_ensure_tag_state", lambda tag: release.TagState(True, True)
+    )
+    monkeypatch.setattr(
+        release,
+        "_prepare_release_notes",
+        lambda name, version: Path("CHANGELOG/1.2.3.md"),
+    )
+    monkeypatch.setattr(release, "_release_notes", lambda *args: ("Release", "Notes"))
+    monkeypatch.setattr(
+        release,
+        "_github_release_exists",
+        lambda tag: (_ for _ in ()).throw(OSError("gh unavailable")),
+    )
+
+    assert release.main() == 1
+
+
 def test_remote_tag_is_fetched_and_verified(release, monkeypatch):
     """A remote-only tag is fetched before the release is resumed."""
     commands = []
@@ -162,7 +272,9 @@ def test_remote_tag_is_fetched_and_verified(release, monkeypatch):
                 command, 1 if show_ref_calls == 1 else 0
             )
         if command[:3] == ("git", "ls-remote", "--exit-code"):
-            return release.subprocess.CompletedProcess(command, 0)
+            return release.subprocess.CompletedProcess(
+                command, 0, stdout="same\trefs/tags/v1.2.3\n"
+            )
         if command[:2] == ("git", "rev-list"):
             return release.subprocess.CompletedProcess(command, 0, stdout="same\n")
         if command[:2] == ("git", "rev-parse"):
@@ -183,7 +295,9 @@ def test_tag_on_another_commit_is_rejected(release, monkeypatch):
         if command[:2] == ("git", "show-ref"):
             return release.subprocess.CompletedProcess(command, 0)
         if command[:3] == ("git", "ls-remote", "--exit-code"):
-            return release.subprocess.CompletedProcess(command, 0)
+            return release.subprocess.CompletedProcess(
+                command, 0, stdout="tag\trefs/tags/v1.2.3\n"
+            )
         if command[:2] == ("git", "rev-list"):
             return release.subprocess.CompletedProcess(command, 0, stdout="tag\n")
         if command[:2] == ("git", "rev-parse"):
@@ -196,6 +310,42 @@ def test_tag_on_another_commit_is_rejected(release, monkeypatch):
         release.ReleaseError, match="does not point to the current HEAD"
     ):
         release._ensure_tag_state("v1.2.3")
+
+
+def test_remote_tag_on_another_commit_is_rejected(release, monkeypatch):
+    """A remote tag that differs from the local tag cannot be reused."""
+
+    def fake_command_result(*command):
+        if command[:2] == ("git", "show-ref"):
+            return release.subprocess.CompletedProcess(command, 0)
+        if command[:3] == ("git", "ls-remote", "--exit-code"):
+            return release.subprocess.CompletedProcess(
+                command, 0, stdout="remote\trefs/tags/v1.2.3\n"
+            )
+        if command[:2] == ("git", "rev-list"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="local\n")
+        if command[:2] == ("git", "rev-parse"):
+            return release.subprocess.CompletedProcess(command, 0, stdout="local\n")
+        raise AssertionError(f"Unexpected command: {command}")
+
+    monkeypatch.setattr(release, "_command_result", fake_command_result)
+
+    with pytest.raises(release.ReleaseError, match="differs between local and origin"):
+        release._ensure_tag_state("v1.2.3")
+
+
+def test_missing_executable_returns_a_readable_command_error(release, monkeypatch):
+    """Missing tools are represented as command failures instead of crashing."""
+
+    def missing_executable(*command, **kwargs):
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(release.subprocess, "run", missing_executable)
+
+    result = release._command_result("gh", "release", "view", "v1.2.3")
+
+    assert result.returncode == 127
+    assert result.stderr == "gh"
 
 
 @pytest.mark.parametrize(

--- a/{{cookiecutter.package_name}}/CHANGELOG/unreleased.md
+++ b/{{cookiecutter.package_name}}/CHANGELOG/unreleased.md
@@ -1,21 +1,21 @@
 # Unreleased
 
-Record user-visible changes here before the next release.
+These are the changes that will go out in the next release.
 
 ## Added
+
+{{ cookiecutter.project_name }} started out as a project generated from [Cookiecutter PyPackage](https://github.com/audreyfeldroy/cookiecutter-pypackage) containing:
 
 - Initial scaffold for {{ cookiecutter.project_name }}.
 - `src/{{ cookiecutter.import_name }}/` package with CLI (Typer + Rich), py.typed marker
 - Tests with pytest, coverage across Python 3.12/3.13/3.14
 - CI via GitHub Actions: lint (Ruff), type check (ty), test matrix, coverage reporting
-- Security scanning: CodeQL analysis for public repositories, Dependabot, and a zizmor workflow audit
+- Security scanning: CodeQL analysis for public repositories, Dependabot, and a Zizmor workflow audit
 - Docs site with Zensical + mkdocstrings and a GitHub Pages deployment workflow
 - Trusted publishing to PyPI with OIDC and build provenance attestation
 - `justfile` with dev commands: qa, test, type-check, docs-serve, release
 - Issue templates, PR template, contributing guide, code of conduct, security policy
 - MIT license, .editorconfig, .gitignore
-
-Built with [Cookiecutter PyPackage](https://github.com/audreyfeldroy/cookiecutter-pypackage).
 
 ### Contributors
 

--- a/{{cookiecutter.package_name}}/CHANGELOG/unreleased.md
+++ b/{{cookiecutter.package_name}}/CHANGELOG/unreleased.md
@@ -1,15 +1,10 @@
-## {{ cookiecutter.project_name }} {{ cookiecutter.first_version }}
+# Unreleased
 
-{{ cookiecutter.project_short_description }}
+Record user-visible changes here before the next release.
 
-This release reserves the PyPI package name and establishes the project scaffold.
+## Added
 
-```sh
-uv add {{ cookiecutter.package_name }}
-```
-
-### What's in the scaffold
-
+- Initial scaffold for {{ cookiecutter.project_name }}.
 - `src/{{ cookiecutter.import_name }}/` package with CLI (Typer + Rich), py.typed marker
 - Tests with pytest, coverage across Python 3.12/3.13/3.14
 - CI via GitHub Actions: lint (Ruff), type check (ty), test matrix, coverage reporting

--- a/{{cookiecutter.package_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.package_name}}/CONTRIBUTING.md
@@ -112,25 +112,29 @@ uv run pytest tests/
 
 ## Releasing a New Version
 
-1. **Bump the version** and **write the changelog:**
+1. **Bump the version:**
    ```bash
    uv version <version>        # or: uv version --bump minor
    ```
-   Then write `CHANGELOG/<version>.md`. See previous entries for the format.
 2. **Commit:**
    ```bash
-   git add pyproject.toml uv.lock CHANGELOG/
-   git commit -m "Release <version>"
+   git add pyproject.toml uv.lock
+   git commit -m "Bump version to <version>"
    ```
 3. **Release:**
    ```bash
    just release
    ```
-   This creates an annotated `v*` tag, pushes it to GitHub, and creates a
-   GitHub Release with the changelog contents as release notes. The tag
-   push triggers `.github/workflows/publish.yml`, which builds the package,
-   generates SLSA provenance attestations, and publishes to PyPI via
-   trusted publishing.
+   This finalizes `CHANGELOG/unreleased.md` as
+   `CHANGELOG/<version>.md`, creates a fresh unreleased file, commits and
+   pushes that notes commit, then creates an annotated `v*` tag and GitHub
+   Release. The tag push triggers `.github/workflows/publish.yml`, which
+   builds the package, generates SLSA provenance attestations, and publishes
+   to PyPI via trusted publishing.
+
+Record release-worthy changes in `CHANGELOG/unreleased.md` as they merge.
+Projects generated before this changelog lifecycle was introduced remain
+compatible when they already have a versioned changelog file.
 
 ## Code of Conduct
 

--- a/{{cookiecutter.package_name}}/justfile
+++ b/{{cookiecutter.package_name}}/justfile
@@ -70,7 +70,7 @@ build:
     rm -rf dist
     uv build
 
-# Tag, push, and create a GitHub release
+# Finalize release notes, tag, push, and create a GitHub release
 release:
     uv run scripts/release.py
 

--- a/{{cookiecutter.package_name}}/scripts/release.py
+++ b/{{cookiecutter.package_name}}/scripts/release.py
@@ -26,12 +26,18 @@ class TagState(NamedTuple):
 
 def _run(*cmd: str) -> None:
     print(f"$ {' '.join(cmd)}")  # noqa: T201
-    subprocess.run(cmd, check=True)
+    try:
+        subprocess.run(cmd, check=True)
+    except OSError as error:
+        raise ReleaseError(f"Could not run {' '.join(cmd)}: {error}") from error
 
 
 def _command_result(*cmd: str) -> subprocess.CompletedProcess[str]:
     """Run a read-only command and return its result without raising."""
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except OSError as error:
+        return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(error))
 
 
 def _ensure_clean_worktree() -> None:
@@ -52,11 +58,24 @@ def _ensure_tag_state(tag: str) -> TagState:
         raise ReleaseError(f"Could not check local tag {tag}: {error}")
     local_exists = local.returncode == 0
 
-    remote = _command_result("git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}")
+    remote = _command_result(
+        "git",
+        "ls-remote",
+        "--exit-code",
+        "--tags",
+        "origin",
+        f"refs/tags/{tag}*",
+    )
     if remote.returncode not in {0, 2}:
         error = (remote.stderr or remote.stdout).strip() or "unknown error"
         raise ReleaseError(f"Could not check whether {tag} exists on origin: {error}")
-    remote_exists = remote.returncode == 0
+    remote_lines = [line.split("\t", 1) for line in remote.stdout.splitlines() if "\t" in line]
+    remote_refs = {ref: commit for commit, ref in remote_lines}
+    remote_tag_ref = f"refs/tags/{tag}"
+    remote_commit = remote_refs.get(remote_tag_ref + "^{}") or remote_refs.get(remote_tag_ref)
+    if remote.returncode == 0 and remote_commit is None:
+        raise ReleaseError(f"Could not determine which commit remote tag {tag} points to.")
+    remote_exists = remote_commit is not None
 
     if remote_exists and not local_exists:
         _run("git", "fetch", "origin", "tag", tag)
@@ -70,7 +89,10 @@ def _ensure_tag_state(tag: str) -> TagState:
         head_commit = _command_result("git", "rev-parse", "HEAD")
         if tag_commit.returncode != 0 or head_commit.returncode != 0:
             raise ReleaseError(f"Could not verify that tag {tag} points to HEAD.")
-        if tag_commit.stdout.strip() != head_commit.stdout.strip():
+        local_commit = tag_commit.stdout.strip()
+        if remote_commit and remote_commit != local_commit:
+            raise ReleaseError(f"Git tag {tag} differs between local and origin.")
+        if local_commit != head_commit.stdout.strip():
             raise ReleaseError(f"Git tag {tag} does not point to the current HEAD.")
 
     return TagState(local_exists, remote_exists)
@@ -120,6 +142,7 @@ def _prepare_release_notes(name: str, version: str) -> Path:
         versioned_contents = versioned_path.read_text(encoding="utf-8")
         unreleased_contents = UNRELEASED_PATH.read_text(encoding="utf-8")
         if _has_release_notes(versioned_contents) and _is_unreleased_template(unreleased_contents):
+            _run("git", "push", "origin", "HEAD")
             return versioned_path
         raise ReleaseError("Both release changelog files exist; resolve the state manually.")
     if versioned_path.exists():
@@ -192,6 +215,9 @@ def main() -> int:
         print(f"Release aborted: {error}")  # noqa: T201
         return 1
     except subprocess.CalledProcessError as error:
+        print(f"Release command failed: {error}")  # noqa: T201
+        return 1
+    except OSError as error:
         print(f"Release command failed: {error}")  # noqa: T201
         return 1
     return 0

--- a/{{cookiecutter.package_name}}/scripts/release.py
+++ b/{{cookiecutter.package_name}}/scripts/release.py
@@ -10,6 +10,7 @@ from typing import NamedTuple
 
 CHANGELOG_DIR = Path("CHANGELOG")
 UNRELEASED_PATH = CHANGELOG_DIR / "unreleased.md"
+RELEASE_BRANCH = "main"
 UNRELEASED_TEMPLATE = "# Unreleased\n\nRecord user-visible changes here before the next release.\n"
 
 
@@ -50,6 +51,35 @@ def _ensure_clean_worktree() -> None:
         raise ReleaseError("Git worktree is not clean; commit or stash changes first.")
 
 
+def _ensure_release_branch() -> None:
+    """Require HEAD to be the current commit on the protected release branch."""
+    branch = _command_result("git", "branch", "--show-current")
+    if branch.returncode != 0:
+        error = (branch.stderr or branch.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not inspect the current Git branch: {error}")
+    if branch.stdout.strip() != RELEASE_BRANCH:
+        raise ReleaseError(f"Releases must run from the {RELEASE_BRANCH} branch.")
+
+    head = _command_result("git", "rev-parse", "HEAD")
+    remote = _command_result("git", "ls-remote", "--exit-code", "origin", f"refs/heads/{RELEASE_BRANCH}")
+    if head.returncode != 0 or remote.returncode not in {0, 2}:
+        error = (head.stderr or remote.stderr or head.stdout or remote.stdout).strip()
+        raise ReleaseError(f"Could not verify that {RELEASE_BRANCH} matches origin: {error or 'unknown error'}")
+    remote_lines = [line.split("\t", 1) for line in remote.stdout.splitlines() if "\t" in line]
+    remote_refs = {ref: commit for commit, ref in remote_lines}
+    remote_commit = remote_refs.get(f"refs/heads/{RELEASE_BRANCH}")
+    if remote_commit is None:
+        raise ReleaseError(f"origin does not have a {RELEASE_BRANCH} branch.")
+    if head.stdout.strip() != remote_commit:
+        raise ReleaseError(f"{RELEASE_BRANCH} must match origin/{RELEASE_BRANCH} before release.")
+
+
+def _push_release_branch() -> None:
+    """Push prepared release work and re-verify the protected branch."""
+    _run("git", "push", "origin", f"HEAD:{RELEASE_BRANCH}")
+    _ensure_release_branch()
+
+
 def _ensure_tag_state(tag: str) -> TagState:
     """Validate an existing tag so interrupted releases can be resumed safely."""
     local = _command_result("git", "show-ref", "--verify", "--quiet", f"refs/tags/{tag}")
@@ -59,12 +89,7 @@ def _ensure_tag_state(tag: str) -> TagState:
     local_exists = local.returncode == 0
 
     remote = _command_result(
-        "git",
-        "ls-remote",
-        "--exit-code",
-        "--tags",
-        "origin",
-        f"refs/tags/{tag}*",
+        "git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}", f"refs/tags/{tag}^" + "{}"
     )
     if remote.returncode not in {0, 2}:
         error = (remote.stderr or remote.stdout).strip() or "unknown error"
@@ -73,8 +98,6 @@ def _ensure_tag_state(tag: str) -> TagState:
     remote_refs = {ref: commit for commit, ref in remote_lines}
     remote_tag_ref = f"refs/tags/{tag}"
     remote_commit = remote_refs.get(remote_tag_ref + "^{}") or remote_refs.get(remote_tag_ref)
-    if remote.returncode == 0 and remote_commit is None:
-        raise ReleaseError(f"Could not determine which commit remote tag {tag} points to.")
     remote_exists = remote_commit is not None
 
     if remote_exists and not local_exists:
@@ -142,7 +165,6 @@ def _prepare_release_notes(name: str, version: str) -> Path:
         versioned_contents = versioned_path.read_text(encoding="utf-8")
         unreleased_contents = UNRELEASED_PATH.read_text(encoding="utf-8")
         if _has_release_notes(versioned_contents) and _is_unreleased_template(unreleased_contents):
-            _run("git", "push", "origin", "HEAD")
             return versioned_path
         raise ReleaseError("Both release changelog files exist; resolve the state manually.")
     if versioned_path.exists():
@@ -165,7 +187,6 @@ def _prepare_release_notes(name: str, version: str) -> Path:
     UNRELEASED_PATH.write_text(UNRELEASED_TEMPLATE, encoding="utf-8")
     _run("git", "add", str(versioned_path), str(UNRELEASED_PATH))
     _run("git", "commit", "-m", f"Prepare release notes for v{version}")
-    _run("git", "push", "origin", "HEAD")
     return versioned_path
 
 
@@ -190,8 +211,10 @@ def main() -> int:
         tag = f"v{version}"
 
         _ensure_clean_worktree()
+        _ensure_release_branch()
         _ensure_tag_state(tag)
         notes_path = _prepare_release_notes(name, version)
+        _push_release_branch()
         title, notes = _release_notes(notes_path, name, version)
 
         tag_state = _ensure_tag_state(tag)

--- a/{{cookiecutter.package_name}}/scripts/release.py
+++ b/{{cookiecutter.package_name}}/scripts/release.py
@@ -1,11 +1,19 @@
 # /// script
 # requires-python = ">=3.10"
 # ///
-"""Tag the current version and create a GitHub release."""
+"""Finalize release notes, tag the current version, and create a GitHub release."""
 
 import subprocess
 import tomllib
 from pathlib import Path
+
+CHANGELOG_DIR = Path("CHANGELOG")
+UNRELEASED_PATH = CHANGELOG_DIR / "unreleased.md"
+UNRELEASED_TEMPLATE = "# Unreleased\n\nRecord user-visible changes here before the next release.\n"
+
+
+class ReleaseError(RuntimeError):
+    """Raised when release preconditions are not satisfied."""
 
 
 def _run(*cmd: str) -> None:
@@ -13,36 +21,129 @@ def _run(*cmd: str) -> None:
     subprocess.run(cmd, check=True)
 
 
-def main() -> None:
-    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
-    name = pyproject["project"]["name"]
-    version = pyproject["project"]["version"]
-    tag = f"v{version}"
-    notes_path = Path(f"CHANGELOG/{version}.md")
+def _command_result(*cmd: str) -> subprocess.CompletedProcess[str]:
+    """Run a read-only command and return its result without raising."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
 
-    lines = notes_path.read_text().splitlines(keepends=True)
+
+def _ensure_clean_worktree() -> None:
+    """Require all release preparation work to be committed already."""
+    result = _command_result("git", "status", "--porcelain")
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not inspect the Git worktree: {error}")
+    if result.stdout.strip():
+        raise ReleaseError("Git worktree is not clean; commit or stash changes first.")
+
+
+def _ensure_tag_available(tag: str) -> None:
+    """Reject releases whose tag already exists locally or on origin."""
+    local = _command_result("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}")
+    if local.returncode == 0:
+        raise ReleaseError(f"Git tag {tag} already exists locally.")
+
+    remote = _command_result("git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}")
+    if remote.returncode == 0:
+        raise ReleaseError(f"Git tag {tag} already exists on origin.")
+    if remote.returncode != 2:
+        error = (remote.stderr or remote.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not check whether {tag} exists on origin: {error}")
+
+
+def _has_release_notes(contents: str) -> bool:
+    """Return whether unreleased.md contains notes rather than only its template."""
+    lines = [line.strip() for line in contents.splitlines() if line.strip()]
+    normalized = "\n".join(lines).lower()
+    template_lines = [line.strip() for line in UNRELEASED_TEMPLATE.splitlines() if line.strip()]
+    template = "\n".join(template_lines).lower()
+    return len(lines) > 1 and normalized != template
+
+
+def _finalized_contents(contents: str, name: str, version: str) -> str:
+    """Turn the unreleased heading into a versioned release heading."""
+    lines = contents.splitlines(keepends=True)
+    title = f"# {name} {version}\n"
+    if lines and lines[0].strip().lower() == "# unreleased":
+        lines[0] = title
+        return "".join(lines)
+    return f"{title}\n{contents.lstrip()}"
+
+
+def _prepare_release_notes(name: str, version: str) -> Path:
+    """Finalize unreleased notes, preserving compatibility with older projects."""
+    versioned_path = CHANGELOG_DIR / f"{version}.md"
+    if versioned_path.exists() and UNRELEASED_PATH.exists():
+        raise ReleaseError("Both release changelog files exist; resolve the state manually.")
+    if versioned_path.exists():
+        if not _has_release_notes(versioned_path.read_text(encoding="utf-8")):
+            raise ReleaseError(f"{versioned_path} does not contain release notes.")
+        return versioned_path
+    if not UNRELEASED_PATH.exists():
+        raise ReleaseError("No release changelog exists; add release notes first.")
+
+    contents = UNRELEASED_PATH.read_text(encoding="utf-8")
+    if not _has_release_notes(contents):
+        raise ReleaseError(f"{UNRELEASED_PATH} does not contain release notes.")
+
+    versioned_path.parent.mkdir(parents=True, exist_ok=True)
+    UNRELEASED_PATH.rename(versioned_path)
+    versioned_path.write_text(
+        _finalized_contents(contents, name, version),
+        encoding="utf-8",
+    )
+    UNRELEASED_PATH.write_text(UNRELEASED_TEMPLATE, encoding="utf-8")
+    _run("git", "add", str(versioned_path), str(UNRELEASED_PATH))
+    _run("git", "commit", "-m", f"Prepare release notes for v{version}")
+    _run("git", "push", "origin", "HEAD")
+    return versioned_path
+
+
+def _release_notes(notes_path: Path, name: str, version: str) -> tuple[str, str]:
+    """Read the GitHub Release title and body from a versioned notes file."""
+    lines = notes_path.read_text(encoding="utf-8").splitlines(keepends=True)
     title = f"{name} {version}"
     if lines and lines[0].startswith("# "):
         title = lines[0].lstrip("# ").strip()
         lines = lines[1:]
         if lines and not lines[0].strip():
             lines = lines[1:]
-    notes = "".join(lines).rstrip()
+    return title, "".join(lines).rstrip()
 
-    _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
-    _run("git", "push", "origin", tag)
-    _run(
-        "gh",
-        "release",
-        "create",
-        tag,
-        "--verify-tag",
-        "--title",
-        title,
-        "--notes",
-        notes,
-    )
+
+def main() -> int:
+    """Run all release preflight checks and publish the release."""
+    try:
+        pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+        name = pyproject["project"]["name"]
+        version = pyproject["project"]["version"]
+        tag = f"v{version}"
+
+        _ensure_clean_worktree()
+        _ensure_tag_available(tag)
+        notes_path = _prepare_release_notes(name, version)
+        title, notes = _release_notes(notes_path, name, version)
+
+        _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
+        _run("git", "push", "origin", tag)
+        _run(
+            "gh",
+            "release",
+            "create",
+            tag,
+            "--verify-tag",
+            "--title",
+            title,
+            "--notes",
+            notes,
+        )
+    except ReleaseError as error:
+        print(f"Release aborted: {error}")  # noqa: T201
+        return 1
+    except subprocess.CalledProcessError as error:
+        print(f"Release command failed: {error}")  # noqa: T201
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/{{cookiecutter.package_name}}/scripts/release.py
+++ b/{{cookiecutter.package_name}}/scripts/release.py
@@ -6,6 +6,7 @@
 import subprocess
 import tomllib
 from pathlib import Path
+from typing import NamedTuple
 
 CHANGELOG_DIR = Path("CHANGELOG")
 UNRELEASED_PATH = CHANGELOG_DIR / "unreleased.md"
@@ -14,6 +15,13 @@ UNRELEASED_TEMPLATE = "# Unreleased\n\nRecord user-visible changes here before t
 
 class ReleaseError(RuntimeError):
     """Raised when release preconditions are not satisfied."""
+
+
+class TagState(NamedTuple):
+    """Whether the release tag exists locally and on the remote."""
+
+    local: bool
+    remote: bool
 
 
 def _run(*cmd: str) -> None:
@@ -36,18 +44,47 @@ def _ensure_clean_worktree() -> None:
         raise ReleaseError("Git worktree is not clean; commit or stash changes first.")
 
 
-def _ensure_tag_available(tag: str) -> None:
-    """Reject releases whose tag already exists locally or on origin."""
-    local = _command_result("git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}")
-    if local.returncode == 0:
-        raise ReleaseError(f"Git tag {tag} already exists locally.")
+def _ensure_tag_state(tag: str) -> TagState:
+    """Validate an existing tag so interrupted releases can be resumed safely."""
+    local = _command_result("git", "show-ref", "--verify", "--quiet", f"refs/tags/{tag}")
+    if local.returncode not in {0, 1}:
+        error = (local.stderr or local.stdout).strip() or "unknown error"
+        raise ReleaseError(f"Could not check local tag {tag}: {error}")
+    local_exists = local.returncode == 0
 
     remote = _command_result("git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}")
-    if remote.returncode == 0:
-        raise ReleaseError(f"Git tag {tag} already exists on origin.")
-    if remote.returncode != 2:
+    if remote.returncode not in {0, 2}:
         error = (remote.stderr or remote.stdout).strip() or "unknown error"
         raise ReleaseError(f"Could not check whether {tag} exists on origin: {error}")
+    remote_exists = remote.returncode == 0
+
+    if remote_exists and not local_exists:
+        _run("git", "fetch", "origin", "tag", tag)
+        local = _command_result("git", "show-ref", "--verify", "--quiet", f"refs/tags/{tag}")
+        if local.returncode != 0:
+            raise ReleaseError(f"Could not fetch tag {tag} from origin.")
+        local_exists = True
+
+    if local_exists:
+        tag_commit = _command_result("git", "rev-list", "-n", "1", f"refs/tags/{tag}^" + "{commit}")
+        head_commit = _command_result("git", "rev-parse", "HEAD")
+        if tag_commit.returncode != 0 or head_commit.returncode != 0:
+            raise ReleaseError(f"Could not verify that tag {tag} points to HEAD.")
+        if tag_commit.stdout.strip() != head_commit.stdout.strip():
+            raise ReleaseError(f"Git tag {tag} does not point to the current HEAD.")
+
+    return TagState(local_exists, remote_exists)
+
+
+def _github_release_exists(tag: str) -> bool:
+    """Return whether GitHub already has a release for the tag."""
+    result = _command_result("gh", "release", "view", tag)
+    if result.returncode == 0:
+        return True
+    error = (result.stderr or result.stdout).strip() or "unknown error"
+    if "not found" in error.lower():
+        return False
+    raise ReleaseError(f"Could not check whether GitHub release {tag} exists: {error}")
 
 
 def _has_release_notes(contents: str) -> bool:
@@ -57,6 +94,13 @@ def _has_release_notes(contents: str) -> bool:
     template_lines = [line.strip() for line in UNRELEASED_TEMPLATE.splitlines() if line.strip()]
     template = "\n".join(template_lines).lower()
     return len(lines) > 1 and normalized != template
+
+
+def _is_unreleased_template(contents: str) -> bool:
+    """Return whether unreleased.md is the fresh placeholder created by release."""
+    lines = [line.strip() for line in contents.splitlines() if line.strip()]
+    template_lines = [line.strip() for line in UNRELEASED_TEMPLATE.splitlines() if line.strip()]
+    return lines == template_lines
 
 
 def _finalized_contents(contents: str, name: str, version: str) -> str:
@@ -73,6 +117,10 @@ def _prepare_release_notes(name: str, version: str) -> Path:
     """Finalize unreleased notes, preserving compatibility with older projects."""
     versioned_path = CHANGELOG_DIR / f"{version}.md"
     if versioned_path.exists() and UNRELEASED_PATH.exists():
+        versioned_contents = versioned_path.read_text(encoding="utf-8")
+        unreleased_contents = UNRELEASED_PATH.read_text(encoding="utf-8")
+        if _has_release_notes(versioned_contents) and _is_unreleased_template(unreleased_contents):
+            return versioned_path
         raise ReleaseError("Both release changelog files exist; resolve the state manually.")
     if versioned_path.exists():
         if not _has_release_notes(versioned_path.read_text(encoding="utf-8")):
@@ -119,23 +167,27 @@ def main() -> int:
         tag = f"v{version}"
 
         _ensure_clean_worktree()
-        _ensure_tag_available(tag)
+        _ensure_tag_state(tag)
         notes_path = _prepare_release_notes(name, version)
         title, notes = _release_notes(notes_path, name, version)
 
-        _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
-        _run("git", "push", "origin", tag)
-        _run(
-            "gh",
-            "release",
-            "create",
-            tag,
-            "--verify-tag",
-            "--title",
-            title,
-            "--notes",
-            notes,
-        )
+        tag_state = _ensure_tag_state(tag)
+        if not tag_state.local:
+            _run("git", "tag", "-a", tag, "-m", f"Release {tag}")
+        if not tag_state.remote:
+            _run("git", "push", "origin", tag)
+        if not _github_release_exists(tag):
+            _run(
+                "gh",
+                "release",
+                "create",
+                tag,
+                "--verify-tag",
+                "--title",
+                title,
+                "--notes",
+                notes,
+            )
     except ReleaseError as error:
         print(f"Release aborted: {error}")  # noqa: T201
         return 1


### PR DESCRIPTION
## Summary

This follow-up to #935 makes changelog handling honest for generated projects and makes release automation finalize notes safely.

## Changes

- Generate `CHANGELOG/unreleased.md` instead of a premature versioned changelog.
- Update the outer and generated release documentation and first-commit summary.
- Finalize unreleased notes into `CHANGELOG/<version>.md` before tagging.
- Commit and push the release-notes commit before creating the tag.
- Reject dirty worktrees, empty or ambiguous changelog states, and existing tags.
- Preserve compatibility with older projects that already have versioned notes.
- Add regression coverage for the lifecycle and keep outer/generated release scripts functionally aligned.

## Validation

- `just ci`
- `just testall` on Python 3.12, 3.13, and 3.14
- `just docs-build`
- `uv build`

This PR does not bump the package version or publish a release.