### PR TITLE
Add uv Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
       default-days: 7
     open-pull-requests-limit: 5
 
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5

--- a/{{cookiecutter.package_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.package_name}}/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Enable Dependabot version updates for `uv` dependencies in the outer project and generated-project template.
- Apply the existing seven-day cooldown to those updates.

## Why

The existing Dependabot configuration only covered GitHub Actions, leaving Python/uv dependencies without version-update pull requests or an explicit cooldown.

## Validation

- Parsed both Dependabot YAML files.
- Generated a fresh project with Cookiecutter and verified its uv configuration.