### PR TITLE
Add explicit Just quality recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ uvx cookiecutter-pypackage
 | | Tool | |
 |---|---|---|
 | Package manager | [uv](https://docs.astral.sh/uv/) | Fast, handles venvs automatically |
-| Task runner | [just](https://github.com/casey/just) | `just qa` formats, lints, type-checks, and tests |
+| Task runner | [just](https://github.com/casey/just) | `just fix` applies safe fixes, `just check` verifies, and `just fix-and-check` does both |
 | Linting | [ruff](https://docs.astral.sh/ruff/) | Format + lint in one tool |
 | Type checking | [ty](https://docs.astral.sh/ty/) | All rules enabled, watch mode with `just type-check-watch` |
-| Testing | [pytest](https://docs.pytest.org/) | Python 3.12, 3.13, 3.14 |
+| Testing | [pytest](https://docs.pytest.org/) | `just check` tests Python 3.14; `just testall` and CI cover 3.12, 3.13, and 3.14 |
 | CLI framework | [Typer](https://typer.tiangolo.com/) | Entry point + `__main__.py` included |
 | Docs | [Zensical](https://zensical.org/) + [mkdocstrings](https://mkdocstrings.github.io/) | GitHub Pages deployment, API docs from docstrings |
 

--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -4,13 +4,13 @@ This template is opinionated. Here's why it makes the choices it does.
 
 ## No pre-commit hooks
 
-CI is the enforcement layer, not your commit history. `just qa` runs the same checks locally when you want them. The difference is that `just qa` doesn't stand between you and saving your work.
+CI is the enforcement layer, not your commit history. `just check` runs the local quality gate without changing source files, while `just fix-and-check` applies automatic Ruff fixes before checking. CI additionally runs the test matrix across supported Python versions. None of these commands stand between you and saving your work.
 
 Pre-commit hooks punish frequent committers. If you commit every 5 minutes (good), you pay 12x the hook tax of someone who commits once an hour. They break during interactive rebases, firing on every replayed commit. And they're bypassable with `--no-verify`, so you can't rely on them anyway. CI is where enforcement actually happens.
 
 ## justfile, not Makefile
 
-[just](https://github.com/casey/just) is a command runner, not a build system. It doesn't track file timestamps or have implicit rules. `just qa` means "run these commands in order," which is exactly what you want for a development workflow. Makefiles can do this too, but you're fighting the tool's assumptions about build artifacts the whole time.
+[just](https://github.com/casey/just) is a command runner, not a build system. It doesn't track file timestamps or have implicit rules. `just fix-and-check` means "apply automatic fixes, then run these commands in order," which is exactly what you want for a development workflow. Makefiles can do this too, but you're fighting the tool's assumptions about build artifacts the whole time.
 
 ## ruff, not black + isort + flake8
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Answer a few [prompts](prompts.md) and you'll have a complete project: source co
 
 ## Your project comes ready with
 
-**A real development workflow.** [uv](https://docs.astral.sh/uv/) manages your dependencies and virtual environments. [just](https://github.com/casey/just) gives you one command for everything: `just qa` formats your code with [ruff](https://docs.astral.sh/ruff/), lints it, type-checks with [ty](https://docs.astral.sh/ty/), and runs your [pytest](https://docs.pytest.org/) suite across Python 3.12, 3.13, and 3.14. A [Typer](https://typer.tiangolo.com/) CLI is wired up and working from the first `uv sync`.
+**A real development workflow.** [uv](https://docs.astral.sh/uv/) manages your dependencies and virtual environments. [just](https://github.com/casey/just) gives you explicit quality commands: `just fix` applies Ruff's automatic fixes, `just check` verifies formatting, linting, types, and tests on Python 3.14 without modifying source files, and `just fix-and-check` does both. Use `just testall` for the local Python 3.12, 3.13, and 3.14 test matrix; GitHub CI runs that matrix separately. A [Typer](https://typer.tiangolo.com/) CLI is wired up and working from the first `uv sync`.
 
 **A documentation site ready to deploy.** [Zensical](https://zensical.org/)
 builds your docs with the Material theme, light and dark mode, and
@@ -27,7 +27,7 @@ the site. Preview locally with `just docs-serve`.
 
 **A clean project structure.** [src layout](project_structure.md) so you never accidentally import local code during testing. A [py.typed](https://peps.python.org/pep-0561/) marker and type hints on all starter code. `__main__.py` so your package works with `python -m`. A focused .gitignore instead of the 200-line GitHub default.
 
-**Justfile commands for everything.** `just qa` is the daily driver, but there's also `just test`, `just testall`, `just type-check-watch`, `just coverage`, `just docs-serve`, `just release`, and more. Run `just list` to see them all. See [Project Structure](project_structure.md#justfile-commands) for the full table.
+**Justfile commands for everything.** Use `just fix-and-check` for the daily workflow, or run `just fix` and `just check` separately. There are also focused commands including `just test`, `just testall`, `just type-check-watch`, `just coverage`, `just docs-serve`, and `just release`. Run `just list` to see them all. See [Project Structure](project_structure.md#justfile-commands) for the full table.
 
 **Your name on it.** The generated README includes a bold "Created by" line linking to your GitHub profile, PyPI profile, and personal website. You built the package, you should get the credit.
 

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -72,7 +72,9 @@ Run `just list` to see all available commands. The key ones:
 
 | Command | What it does |
 |---|---|
-| `just qa` | Format, lint, type-check, and test (the daily driver) |
+| `just fix` | Apply Ruff formatting and safe lint fixes |
+| `just check` | Verify formatting, linting, types, and Python 3.14 tests without modifying source files |
+| `just fix-and-check` | Apply automatic fixes, then run the local quality gate |
 | `just test` | Run tests only |
 | `just testall` | Run tests on Python 3.12, 3.13, and 3.14 |
 | `just type-check` | Type-check with ty |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -126,10 +126,10 @@ The project uses a `src` layout, meaning your package code lives under `src/` ra
 
 ```bash
 uv sync
-just qa
+just fix-and-check
 ```
 
-`just qa` formats your code with ruff, lints it, type-checks with ty, and runs tests. If ruff reformats any files, that's expected. You should see all checks pass.
+`just fix-and-check` applies Ruff's automatic formatting and lint fixes, then runs the local quality gate: formatting and lint checks, ty, and tests on Python 3.14. Use `just check` when you only want read-only verification; use `just testall` for the local Python 3.12, 3.13, and 3.14 test matrix.
 
 Try the CLI:
 
@@ -169,7 +169,7 @@ def test_add():
     assert add(1, 2) == 3
 ```
 
-Run `just qa` to verify everything still passes. Push your changes and watch CI confirm it on GitHub too.
+Run `just check` to verify everything still passes without changing your files. Push your changes and watch CI confirm the full Python-version matrix on GitHub too.
 
 ## Step 6: Set up PyPI publishing
 

--- a/justfile
+++ b/justfile
@@ -36,21 +36,26 @@ pdb *ARGS:
     @echo "Running with arg: {{ARGS}}"
     uv run --python=3.14 pytest --pdb --maxfail=10 {{ARGS}}
 
-# Run all the formatting, linting, type checking, and testing commands
-qa:
+# Apply automatic formatting and lint fixes
+fix:
     uv run --python=3.14 ruff format .
     uv run --python=3.14 ruff check . --fix
-    uv run --python=3.14 ruff check --select I --fix .
+
+# Verify formatting, linting, types, and tests on Python 3.14 without modifying source files
+check:
+    uv run --python=3.14 ruff format --check .
+    uv run --python=3.14 ruff check .
     uv run --python=3.14 ty check .
     uv run --python=3.14 pytest
 
-# Run all the checks for CI
-ci:
-    uv run --python=3.14 ruff format --check .
-    uv run --python=3.14 ruff check .
-    uv run --python=3.14 ruff check --select I .
-    uv run --python=3.14 ty check .
-    uv run --python=3.14 pytest
+# Apply automatic fixes, then run the local quality gate
+fix-and-check: fix check
+
+# Compatibility alias for fix-and-check
+qa: fix-and-check
+
+# Compatibility alias for check
+ci: check
 
 # Run all the tests for all the supported Python versions
 testall:

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -157,10 +157,20 @@ def test_bake_treats_import_name_as_data(cookies, tmp_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="justfile not supported on Windows")
-def test_just_list(cookies):
+def test_just_quality_recipes(cookies):
     result = cookies.bake()
-    output = check_output_inside_dir("just list", str(result.project_path))
+    project_path = str(result.project_path)
+    output = check_output_inside_dir("just list", project_path)
+
     assert b"Show available commands" in output
+    assert b"fix" in output
+    assert b"check" in output
+    assert b"fix-and-check" in output
+    assert b"\n    ci " not in output
+
+    run_inside_dir("just fix", project_path)
+    run_inside_dir("just check", project_path)
+    run_inside_dir("just fix-and-check", project_path)
 
 
 def test_py_typed_marker_exists(cookies):

--- a/{{cookiecutter.package_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.package_name}}/CONTRIBUTING.md
@@ -72,11 +72,13 @@ Ready to contribute? Here's how to set up {{ cookiecutter.package_name }} for lo
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass linting and the tests:
+5. When you're done making changes, verify formatting, linting, types, and tests without modifying files:
 
    ```sh
-   just qa
+   just check
    ```
+
+   Use `just fix` to apply Ruff's automatic fixes, or `just fix-and-check` to apply them before verification.
 
    Or run the tests alone:
 

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -58,11 +58,15 @@ Run tests:
 uv run pytest
 ```
 
-Run quality checks (format, lint, type check, test):
+Use the quality commands:
 
 ```bash
-just qa
+just fix             # apply Ruff formatting and safe lint fixes
+just check           # verify formatting, linting, types, and Python 3.14 tests
+just fix-and-check   # apply fixes, then verify
 ```
+
+Use `just testall` to run tests on Python 3.12, 3.13, and 3.14. GitHub CI runs that test matrix on every push and pull request.
 
 ## Author
 

--- a/{{cookiecutter.package_name}}/justfile
+++ b/{{cookiecutter.package_name}}/justfile
@@ -22,13 +22,23 @@ type-check-concise:
 type-check-watch:
     uv run --python=3.14 ty check --watch .
 
-# Run all the formatting, linting, and testing commands
-qa:
+# Apply automatic formatting and lint fixes
+fix:
     uv run --python=3.14 ruff format .
     uv run --python=3.14 ruff check . --fix
-    uv run --python=3.14 ruff check --select I --fix .
-    uv run --python=3.14 ty check --output-format=concise .
+
+# Verify formatting, linting, types, and tests on Python 3.14 without modifying source files
+check:
+    uv run --python=3.14 ruff format --check .
+    uv run --python=3.14 ruff check .
+    uv run --python=3.14 ty check .
     uv run --python=3.14 pytest
+
+# Apply automatic fixes, then run the local quality gate
+fix-and-check: fix check
+
+# Compatibility alias for fix-and-check
+qa: fix-and-check
 
 # Run all the tests for all the supported Python versions
 testall:


### PR DESCRIPTION
## Summary

- Add explicit `fix`, `check`, and `fix-and-check` recipes to both project layers.
- Retain the required `qa` compatibility alias and the outer-only `ci` alias.
- Update primary documentation and exercise the rendered generated-project recipes.

Closes #934.

## Validation

- `just fix`
- `just check`
- `just fix-and-check`
- `just testall` (Python 3.12, 3.13, and 3.14)
- `just docs-build`